### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/431/421168431.geojson
+++ b/data/421/168/431/421168431.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008764,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"18f4c1db439a50b0be825fa044fc6719",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421168431,
-    "wof:lastmodified":1566657069,
+    "wof:lastmodified":1582361966,
     "wof:name":"El Sauce",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/170/019/421170019.geojson
+++ b/data/421/170/019/421170019.geojson
@@ -177,6 +177,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008834,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"83f18cd25e0f61721d4a8742088891c4",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":421170019,
-    "wof:lastmodified":1566657092,
+    "wof:lastmodified":1582361968,
     "wof:name":"Masaya",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/170/023/421170023.geojson
+++ b/data/421/170/023/421170023.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008834,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b4b6b815f30b0d88f3cac1e86c7e7dc",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421170023,
-    "wof:lastmodified":1566657091,
+    "wof:lastmodified":1582361967,
     "wof:name":"Jalapa",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/421/170/061/421170061.geojson
+++ b/data/421/170/061/421170061.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008835,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a54d22040fde3626fe2f2bfc0057aa9",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421170061,
-    "wof:lastmodified":1566657092,
+    "wof:lastmodified":1582361968,
     "wof:name":"Condega",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/421/170/189/421170189.geojson
+++ b/data/421/170/189/421170189.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008842,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b36954ea25c797a0179b291eefba3ee9",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421170189,
-    "wof:lastmodified":1566657091,
+    "wof:lastmodified":1582361967,
     "wof:name":"El Viejo",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/170/971/421170971.geojson
+++ b/data/421/170/971/421170971.geojson
@@ -147,6 +147,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008876,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfbeebd19f4f3c464cb6ef6f52a2fb97",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":421170971,
-    "wof:lastmodified":1566657091,
+    "wof:lastmodified":1582361968,
     "wof:name":"Ocotal",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/421/171/365/421171365.geojson
+++ b/data/421/171/365/421171365.geojson
@@ -183,6 +183,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008891,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e3558a5626eb78b406ab6028bd32c94",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":421171365,
-    "wof:lastmodified":1566657098,
+    "wof:lastmodified":1582361968,
     "wof:name":"Chinandega",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/171/539/421171539.geojson
+++ b/data/421/171/539/421171539.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008897,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"527c84415c80725956f72374b7294ae5",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421171539,
-    "wof:lastmodified":1566657099,
+    "wof:lastmodified":1582361968,
     "wof:name":"Matagalpa",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/171/787/421171787.geojson
+++ b/data/421/171/787/421171787.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69b29b8b74aa60255d0e4f6c33b014d4",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421171787,
-    "wof:lastmodified":1566657100,
+    "wof:lastmodified":1582361968,
     "wof:name":"Teustepe",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/421/171/789/421171789.geojson
+++ b/data/421/171/789/421171789.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec9ecc41e585122c3386f8f8efa2799a",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421171789,
-    "wof:lastmodified":1566657100,
+    "wof:lastmodified":1582361968,
     "wof:name":"Diriomo",
     "wof:parent_id":85675477,
     "wof:placetype":"county",

--- a/data/421/171/791/421171791.geojson
+++ b/data/421/171/791/421171791.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b982cafdc0234597b702d3ae47a4c72",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421171791,
-    "wof:lastmodified":1566657098,
+    "wof:lastmodified":1582361968,
     "wof:name":"Nandaime",
     "wof:parent_id":85675477,
     "wof:placetype":"county",

--- a/data/421/171/799/421171799.geojson
+++ b/data/421/171/799/421171799.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f1ff160dff9af159dcf7ac68c672887",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421171799,
-    "wof:lastmodified":1566657098,
+    "wof:lastmodified":1582361968,
     "wof:name":"Somoto",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/421/171/805/421171805.geojson
+++ b/data/421/171/805/421171805.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"887fc60aa81f25ead8ab091679452722",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421171805,
-    "wof:lastmodified":1566657098,
+    "wof:lastmodified":1582361968,
     "wof:name":"Ciudad Dario",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/171/813/421171813.geojson
+++ b/data/421/171/813/421171813.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80f8ebd8c80f56437e6d6eb7eb4ed185",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421171813,
-    "wof:lastmodified":1566657099,
+    "wof:lastmodified":1582361968,
     "wof:name":"El Rama",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/172/641/421172641.geojson
+++ b/data/421/172/641/421172641.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32b8c51dd932ea3c6e51780fed745e8e",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421172641,
-    "wof:lastmodified":1566657081,
+    "wof:lastmodified":1582361966,
     "wof:name":"Jinotega",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/172/925/421172925.geojson
+++ b/data/421/172/925/421172925.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008959,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc2a5317d017553ed8c4f0c26a3c2b8a",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421172925,
-    "wof:lastmodified":1566657081,
+    "wof:lastmodified":1582361966,
     "wof:name":"Quezalguaque",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/173/629/421173629.geojson
+++ b/data/421/173/629/421173629.geojson
@@ -302,6 +302,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459008992,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e81ac552f53a7c841f54d50c6989e8d",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         }
     ],
     "wof:id":421173629,
-    "wof:lastmodified":1566657079,
+    "wof:lastmodified":1582361966,
     "wof:name":"Masaya",
     "wof:parent_id":421170019,
     "wof:placetype":"locality",

--- a/data/421/175/425/421175425.geojson
+++ b/data/421/175/425/421175425.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009067,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d3f9258a86a150da5e7448711988834",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421175425,
-    "wof:lastmodified":1566657085,
+    "wof:lastmodified":1582361967,
     "wof:name":"Nagarote",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/175/427/421175427.geojson
+++ b/data/421/175/427/421175427.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009067,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3ae904e678a6869fd4eab3c6e82aae7",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421175427,
-    "wof:lastmodified":1566657086,
+    "wof:lastmodified":1582361967,
     "wof:name":"Tipitapa",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/175/429/421175429.geojson
+++ b/data/421/175/429/421175429.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009067,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efc555853580311ea57c69eaf7ad7409",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421175429,
-    "wof:lastmodified":1566657085,
+    "wof:lastmodified":1582361967,
     "wof:name":"Bluefields",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/421/176/615/421176615.geojson
+++ b/data/421/176/615/421176615.geojson
@@ -301,6 +301,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009114,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"871417cf8e813b52bf23611eeb1a382c",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         }
     ],
     "wof:id":421176615,
-    "wof:lastmodified":1566657097,
+    "wof:lastmodified":1582361968,
     "wof:name":"Chinandega",
     "wof:parent_id":421171365,
     "wof:placetype":"locality",

--- a/data/421/176/721/421176721.geojson
+++ b/data/421/176/721/421176721.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009117,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84bb165addf6e989812e5446aa762367",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421176721,
-    "wof:lastmodified":1566657098,
+    "wof:lastmodified":1582361968,
     "wof:name":"Rosita",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/421/178/593/421178593.geojson
+++ b/data/421/178/593/421178593.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009187,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"18024f287512b2a580e93316f4bd1d3a",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":421178593,
-    "wof:lastmodified":1566657096,
+    "wof:lastmodified":1582361968,
     "wof:name":"Corinto",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/179/217/421179217.geojson
+++ b/data/421/179/217/421179217.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009208,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e79eb8e660d214e1a6a6b0e40fb4486",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421179217,
-    "wof:lastmodified":1566657094,
+    "wof:lastmodified":1582361968,
     "wof:name":"Ticuantepe",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/179/703/421179703.geojson
+++ b/data/421/179/703/421179703.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009230,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"492e9872266a9dab6d185d363dd5d4e4",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421179703,
-    "wof:lastmodified":1566657095,
+    "wof:lastmodified":1582361968,
     "wof:name":"Telica",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/180/305/421180305.geojson
+++ b/data/421/180/305/421180305.geojson
@@ -420,6 +420,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009251,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4497cd7ca5f6720b2c293da9471e65ea",
     "wof:hierarchy":[
         {
@@ -430,7 +433,7 @@
         }
     ],
     "wof:id":421180305,
-    "wof:lastmodified":1566657079,
+    "wof:lastmodified":1582361966,
     "wof:name":"Managua",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/183/419/421183419.geojson
+++ b/data/421/183/419/421183419.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009368,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69dae6ea795f9f79f0dffcf290e9993d",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421183419,
-    "wof:lastmodified":1566657093,
+    "wof:lastmodified":1582361968,
     "wof:name":"Isla",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/185/081/421185081.geojson
+++ b/data/421/185/081/421185081.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009432,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08dc10e82e355a24c9da3d3f7b80f74a",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421185081,
-    "wof:lastmodified":1566657100,
+    "wof:lastmodified":1582361968,
     "wof:name":"Cinco Pinos",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/186/279/421186279.geojson
+++ b/data/421/186/279/421186279.geojson
@@ -177,6 +177,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009476,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98443d1de0704b38102b74d4cee2d9f2",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":421186279,
-    "wof:lastmodified":1566657083,
+    "wof:lastmodified":1582361967,
     "wof:name":"Bluefields",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/186/609/421186609.geojson
+++ b/data/421/186/609/421186609.geojson
@@ -188,6 +188,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009486,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cdc748d98304feeb9d4c344de983561c",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":421186609,
-    "wof:lastmodified":1566657084,
+    "wof:lastmodified":1582361967,
     "wof:name":"Estel\u00ed",
     "wof:parent_id":1108693753,
     "wof:placetype":"locality",

--- a/data/421/186/611/421186611.geojson
+++ b/data/421/186/611/421186611.geojson
@@ -312,7 +312,8 @@
     "qs:woe_id":152914,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "src:population":"wk",
     "wd:latitude":13.166667,
@@ -337,6 +338,10 @@
     },
     "wof:country":"NI",
     "wof:created":1459009486,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"29d22114c53fb98ac17805d90cbcec5e",
     "wof:hierarchy":[
         {
@@ -348,7 +353,7 @@
         }
     ],
     "wof:id":421186611,
-    "wof:lastmodified":1566657083,
+    "wof:lastmodified":1582361967,
     "wof:name":"Jinotega",
     "wof:parent_id":1108693695,
     "wof:placetype":"locality",

--- a/data/421/186/619/421186619.geojson
+++ b/data/421/186/619/421186619.geojson
@@ -281,6 +281,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009486,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4189499eca70b99cfcd2ae2d89251b2",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         }
     ],
     "wof:id":421186619,
-    "wof:lastmodified":1566657082,
+    "wof:lastmodified":1582361967,
     "wof:name":"Rivas",
     "wof:parent_id":421197835,
     "wof:placetype":"locality",

--- a/data/421/189/523/421189523.geojson
+++ b/data/421/189/523/421189523.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6dac08c78929ff62dc0a4c43a9f6921",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421189523,
-    "wof:lastmodified":1566657080,
+    "wof:lastmodified":1582361966,
     "wof:name":"Camoapa",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/421/189/527/421189527.geojson
+++ b/data/421/189/527/421189527.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009628,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f539d93e39d9c503ace4bf5982521d4",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421189527,
-    "wof:lastmodified":1566657080,
+    "wof:lastmodified":1582361966,
     "wof:name":"Chichigalpa",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/190/545/421190545.geojson
+++ b/data/421/190/545/421190545.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009661,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4aa5d1d5ea8efeb3fc770ed84eb32b63",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421190545,
-    "wof:lastmodified":1566657087,
+    "wof:lastmodified":1582361967,
     "wof:name":"Tola",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/191/489/421191489.geojson
+++ b/data/421/191/489/421191489.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5741a4c696db03e8e59c6bcef14129ae",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421191489,
-    "wof:lastmodified":1566657086,
+    "wof:lastmodified":1582361967,
     "wof:name":"Jinotepe",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/421/192/911/421192911.geojson
+++ b/data/421/192/911/421192911.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009753,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"90823387a63181874de3c98d065c750e",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421192911,
-    "wof:lastmodified":1566657070,
+    "wof:lastmodified":1582361966,
     "wof:name":"Nueva Guinea",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/193/389/421193389.geojson
+++ b/data/421/193/389/421193389.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009769,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4389ea0b85e84f9ccdb7df83a2b908be",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421193389,
-    "wof:lastmodified":1566657073,
+    "wof:lastmodified":1582361966,
     "wof:name":"Isla Mangles Altos",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/193/737/421193737.geojson
+++ b/data/421/193/737/421193737.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009781,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aee2100fbc80402b2ff707f992778611",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421193737,
-    "wof:lastmodified":1566657073,
+    "wof:lastmodified":1582361966,
     "wof:name":"Nandasmo",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/197/135/421197135.geojson
+++ b/data/421/197/135/421197135.geojson
@@ -384,6 +384,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009904,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f259ef7c159c886c97f2e6506ebec2e",
     "wof:hierarchy":[
         {
@@ -394,7 +397,7 @@
         }
     ],
     "wof:id":421197135,
-    "wof:lastmodified":1566657087,
+    "wof:lastmodified":1582361967,
     "wof:name":"Granada",
     "wof:parent_id":85675477,
     "wof:placetype":"county",

--- a/data/421/197/835/421197835.geojson
+++ b/data/421/197/835/421197835.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459009926,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7781900e709facf58cea160ca0568ff3",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":421197835,
-    "wof:lastmodified":1566657088,
+    "wof:lastmodified":1582361967,
     "wof:name":"Rivas",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/200/101/421200101.geojson
+++ b/data/421/200/101/421200101.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010011,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d92aa4c4e03aa0275841cd7446963e1b",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421200101,
-    "wof:lastmodified":1566657089,
+    "wof:lastmodified":1582361967,
     "wof:name":"Rio Blanco",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/200/103/421200103.geojson
+++ b/data/421/200/103/421200103.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010011,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"658ee0324cacb476e40246208ca4edbf",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421200103,
-    "wof:lastmodified":1566657089,
+    "wof:lastmodified":1582361967,
     "wof:name":"Muy Muy",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/200/105/421200105.geojson
+++ b/data/421/200/105/421200105.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010011,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be1b3f3daa3265c5232a72edf99c0f47",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421200105,
-    "wof:lastmodified":1566657089,
+    "wof:lastmodified":1582361967,
     "wof:name":"Terrabona",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/200/107/421200107.geojson
+++ b/data/421/200/107/421200107.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010011,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6eb3cd2bc459af5a5d40655c09363d34",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421200107,
-    "wof:lastmodified":1566657089,
+    "wof:lastmodified":1582361967,
     "wof:name":"Wiwili",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/421/201/657/421201657.geojson
+++ b/data/421/201/657/421201657.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010080,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbc7797a9d05d6946f6f6628512150e3",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421201657,
-    "wof:lastmodified":1566657090,
+    "wof:lastmodified":1582361967,
     "wof:name":"Puerto Cabezas",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/421/202/283/421202283.geojson
+++ b/data/421/202/283/421202283.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2260a793a56bb6f0b47885f569aad7a8",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421202283,
-    "wof:lastmodified":1566657077,
+    "wof:lastmodified":1582361966,
     "wof:name":"Mateare",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/202/287/421202287.geojson
+++ b/data/421/202/287/421202287.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d61edeeed80e33a83e0da9348ae0afdf",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421202287,
-    "wof:lastmodified":1566657076,
+    "wof:lastmodified":1582361966,
     "wof:name":"Buenos Aires",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/289/421202289.geojson
+++ b/data/421/202/289/421202289.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27002a960de1d062dda3b966dee56111",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421202289,
-    "wof:lastmodified":1566657076,
+    "wof:lastmodified":1582361966,
     "wof:name":"Moyogalpa",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/291/421202291.geojson
+++ b/data/421/202/291/421202291.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03556de403127dfb0c66c234a199364a",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421202291,
-    "wof:lastmodified":1566657077,
+    "wof:lastmodified":1582361966,
     "wof:name":"Altagracia",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/293/421202293.geojson
+++ b/data/421/202/293/421202293.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d690dea4b8a1a9c7f43b60f3f7935c4",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421202293,
-    "wof:lastmodified":1566657076,
+    "wof:lastmodified":1582361966,
     "wof:name":"San Jorge",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/297/421202297.geojson
+++ b/data/421/202/297/421202297.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7743a194afa80791d4887cf16add23a4",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421202297,
-    "wof:lastmodified":1566657077,
+    "wof:lastmodified":1582361966,
     "wof:name":"Tola",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/203/775/421203775.geojson
+++ b/data/421/203/775/421203775.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010163,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8cc7be55b924a0c783108c44befb045e",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421203775,
-    "wof:lastmodified":1566657075,
+    "wof:lastmodified":1582361966,
     "wof:name":"Catarina",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/203/777/421203777.geojson
+++ b/data/421/203/777/421203777.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010163,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33eefd6854464fa2e2ff9aedfa2a4c85",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421203777,
-    "wof:lastmodified":1566657075,
+    "wof:lastmodified":1582361966,
     "wof:name":"Masatepe",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/204/571/421204571.geojson
+++ b/data/421/204/571/421204571.geojson
@@ -178,6 +178,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010191,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"696850f4430dc9d1bd8d48e46b919787",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":421204571,
-    "wof:lastmodified":1566657075,
+    "wof:lastmodified":1582361966,
     "wof:name":"San Carlos",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/421/205/285/421205285.geojson
+++ b/data/421/205/285/421205285.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010217,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5791ff68fcc7eb28157bd38de85edd3",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421205285,
-    "wof:lastmodified":1566657078,
+    "wof:lastmodified":1582361966,
     "wof:name":"Plueblo Nuevo",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/421/205/287/421205287.geojson
+++ b/data/421/205/287/421205287.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"NI",
     "wof:created":1459010218,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"297a5e2533126f650158070fcbcb673e",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421205287,
-    "wof:lastmodified":1566657077,
+    "wof:lastmodified":1582361966,
     "wof:name":"San Miguelito",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/856/325/99/85632599.geojson
+++ b/data/856/325/99/85632599.geojson
@@ -948,6 +948,11 @@
     },
     "wof:country":"NI",
     "wof:country_alpha3":"NIC",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"8b04e61db14b5672a4a69c2829c55d7a",
     "wof:hierarchy":[
         {
@@ -962,7 +967,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656859,
+    "wof:lastmodified":1582361962,
     "wof:name":"Nicaragua",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/754/61/85675461.geojson
+++ b/data/856/754/61/85675461.geojson
@@ -255,6 +255,9 @@
         "wk:page":"Rivas Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58aee8bdd6717cd8738baefba4737285",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656855,
+    "wof:lastmodified":1582361961,
     "wof:name":"Rivas",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/65/85675465.geojson
+++ b/data/856/754/65/85675465.geojson
@@ -313,6 +313,9 @@
         "wk:page":"R\u00edo San Juan Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10bfd5606db1fd1bc33892719678b690",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656857,
+    "wof:lastmodified":1582361962,
     "wof:name":"Rio San Juan",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/67/85675467.geojson
+++ b/data/856/754/67/85675467.geojson
@@ -150,6 +150,9 @@
         "unlc:id":"NI-AS"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32b33666c2d392c1c37f52e41f0406eb",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656856,
+    "wof:lastmodified":1582361961,
     "wof:name":"Atl\u00e1ntico Sur",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/71/85675471.geojson
+++ b/data/856/754/71/85675471.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Carazo Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a9383e46b296e99be9140ee7d6cebea",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656858,
+    "wof:lastmodified":1582361962,
     "wof:name":"Carazo",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/77/85675477.geojson
+++ b/data/856/754/77/85675477.geojson
@@ -252,6 +252,9 @@
         "wk:page":"Granada Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"495239baf0b40cf15587f2234a6d87b9",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656857,
+    "wof:lastmodified":1582361962,
     "wof:name":"Granada",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/81/85675481.geojson
+++ b/data/856/754/81/85675481.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Jinotega Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"acff276c2c9c2732dbe1122ca9795154",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656856,
+    "wof:lastmodified":1582361962,
     "wof:name":"Jinotega",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/85/85675485.geojson
+++ b/data/856/754/85/85675485.geojson
@@ -151,6 +151,9 @@
         "unlc:id":"NI-AN"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55c4632c7b0697760714f9917d8af704",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656858,
+    "wof:lastmodified":1582361962,
     "wof:name":"Atl\u00e1ntico Norte",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/89/85675489.geojson
+++ b/data/856/754/89/85675489.geojson
@@ -268,6 +268,9 @@
         "wk:page":"Le\u00f3n Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d38cb2b88975b4e6e4b65ae438a0953",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656856,
+    "wof:lastmodified":1582361962,
     "wof:name":"Le\u00f3n",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/95/85675495.geojson
+++ b/data/856/754/95/85675495.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Managua Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bcefe18debda11cb1adeff3ef44a4824",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656856,
+    "wof:lastmodified":1582361961,
     "wof:name":"Managua",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/99/85675499.geojson
+++ b/data/856/754/99/85675499.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Masaya Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c16ed16004ad9c8c2fdb51f2fa1a588",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656857,
+    "wof:lastmodified":1582361962,
     "wof:name":"Masaya",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/03/85675503.geojson
+++ b/data/856/755/03/85675503.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Chinandega Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b9a12f878247ff7946bc37abdf286bf",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656853,
+    "wof:lastmodified":1582361961,
     "wof:name":"Chinandega",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/05/85675505.geojson
+++ b/data/856/755/05/85675505.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Estel\u00ed Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3937e6d510bb8eb4c0853b25e720047a",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656854,
+    "wof:lastmodified":1582361961,
     "wof:name":"Estel\u00ed",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/11/85675511.geojson
+++ b/data/856/755/11/85675511.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Madriz Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ff33c1f098f710d8f88d7e11ae2df78",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656854,
+    "wof:lastmodified":1582361961,
     "wof:name":"Madriz",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/13/85675513.geojson
+++ b/data/856/755/13/85675513.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Matagalpa Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4bb567dd9d85abad03d2bc58ea18744",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656855,
+    "wof:lastmodified":1582361961,
     "wof:name":"Matagalpa",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/17/85675517.geojson
+++ b/data/856/755/17/85675517.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Nueva Segovia Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f74acb7e8f35f59f663551c7a24cb39",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656854,
+    "wof:lastmodified":1582361961,
     "wof:name":"Nueva Segovia",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/21/85675521.geojson
+++ b/data/856/755/21/85675521.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Boaco Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb42a1202086d96f9f1f27ebbe97cd68",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656854,
+    "wof:lastmodified":1582361961,
     "wof:name":"Boaco",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/25/85675525.geojson
+++ b/data/856/755/25/85675525.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Chontales Department"
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0eaa3dac851487767c729684503554fc",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566656855,
+    "wof:lastmodified":1582361961,
     "wof:name":"Chontales",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/857/940/83/85794083.geojson
+++ b/data/857/940/83/85794083.geojson
@@ -82,6 +82,9 @@
         "qs:id":222192
     },
     "wof:country":"NI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f69185823ce11836fba5d33f2927c3bf",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379386,
+    "wof:lastmodified":1582361960,
     "wof:name":"Monimb\u00f3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/451/731/890451731.geojson
+++ b/data/890/451/731/890451731.geojson
@@ -516,6 +516,9 @@
     },
     "wof:country":"NI",
     "wof:created":1469052791,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"4497cd7ca5f6720b2c293da9471e65ea",
     "wof:hierarchy":[
         {
@@ -527,7 +530,7 @@
         }
     ],
     "wof:id":890451731,
-    "wof:lastmodified":1566657104,
+    "wof:lastmodified":1582361968,
     "wof:name":"Managua",
     "wof:parent_id":421180305,
     "wof:placetype":"locality",

--- a/data/890/451/733/890451733.geojson
+++ b/data/890/451/733/890451733.geojson
@@ -269,6 +269,9 @@
     },
     "wof:country":"NI",
     "wof:created":1469052791,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1a74bd513e99dedddbaa17843e88a826",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
         }
     ],
     "wof:id":890451733,
-    "wof:lastmodified":1566657104,
+    "wof:lastmodified":1582361968,
     "wof:name":"Juigalpa",
     "wof:parent_id":1108693847,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.