### PR TITLE
Update megacity records

### DIFF
--- a/data/890/451/731/890451731.geojson
+++ b/data/890/451/731/890451731.geojson
@@ -512,6 +512,7 @@
     "wof:concordances":{
         "gn:id":3617763,
         "gp:id":153523,
+        "ne:id":1159150623,
         "qs_pg:id":149449,
         "wd:id":"Q3274",
         "wk:page":"Managua"
@@ -535,7 +536,8 @@
         }
     ],
     "wof:id":890451731,
-    "wof:lastmodified":1607993741,
+    "wof:lastmodified":1608688176,
+    "wof:megacity":1,
     "wof:name":"Managua",
     "wof:parent_id":421180305,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary