### PR TITLE
ni concordances, placetype local, and more

### DIFF
--- a/data/110/869/367/3/1108693673.geojson
+++ b/data/110/869/367/3/1108693673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.716958,
-    "geom:area_square_m":8581572249.033707,
+    "geom:area_square_m":8581573571.041708,
     "geom:bbox":"-85.061101,14.123018,-83.183673,15.034255",
     "geom:latitude":14.536613,
     "geom:longitude":-84.216776,
@@ -110,9 +110,10 @@
         "hasc:id":"NI.AN.WP",
         "wd:id":"Q2217458"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415025,
-    "wof:geomhash":"27b5dc6b388e0baa7eb86a5cd5619ce9",
+    "wof:geomhash":"a746479c2fee64aff032daa248a3a8dd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108693673,
-    "wof:lastmodified":1690848464,
+    "wof:lastmodified":1695886489,
     "wof:name":"Waspam",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/110/869/367/5/1108693675.geojson
+++ b/data/110/869/367/5/1108693675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153918,
-    "geom:area_square_m":1846253561.893066,
+    "geom:area_square_m":1846254743.403114,
     "geom:bbox":"-84.935462,13.830396,-84.341045,14.243279",
     "geom:latitude":14.054018,
     "geom:longitude":-84.629282,
@@ -109,9 +109,10 @@
         "hasc:id":"NI.AN.BO",
         "wd:id":"Q892092"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415027,
-    "wof:geomhash":"7784e1ea5500ac1af31d121908e71348",
+    "wof:geomhash":"d925e06238232083482742d6e85f658d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108693675,
-    "wof:lastmodified":1690848464,
+    "wof:lastmodified":1695886489,
     "wof:name":"Bonanza",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/110/869/367/7/1108693677.geojson
+++ b/data/110/869/367/7/1108693677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111134,
-    "geom:area_square_m":1336881252.976832,
+    "geom:area_square_m":1336881252.977061,
     "geom:bbox":"-85.5131920734,13.1426085834,-85.1501796038,13.6153268088",
     "geom:latitude":13.381791,
     "geom:longitude":-85.303209,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"NI.AN.WL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415028,
-    "wof:geomhash":"81fbea84acb2ffd686634beada079878",
+    "wof:geomhash":"51f32f30d7f6c97615d228174936a3a1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693677,
-    "wof:lastmodified":1566657008,
+    "wof:lastmodified":1695886489,
     "wof:name":"Waslala",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/110/869/367/9/1108693679.geojson
+++ b/data/110/869/367/9/1108693679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.422185,
-    "geom:area_square_m":5075075504.85338,
+    "geom:area_square_m":5075074910.929218,
     "geom:bbox":"-85.431659,13.144478,-84.441893,13.914134",
     "geom:latitude":13.551947,
     "geom:longitude":-84.89851,
@@ -112,9 +112,10 @@
         "hasc:id":"NI.AN.SN",
         "wd:id":"Q1329302"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415030,
-    "wof:geomhash":"0eedbc7250a8440b742e6d03db41ea25",
+    "wof:geomhash":"9f12a587474b82b69f5f4f6c60745f99",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108693679,
-    "wof:lastmodified":1690848464,
+    "wof:lastmodified":1695886489,
     "wof:name":"Siuna",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/110/869/368/1/1108693681.geojson
+++ b/data/110/869/368/1/1108693681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.568913,
-    "geom:area_square_m":6840443761.785976,
+    "geom:area_square_m":6840444361.226569,
     "geom:bbox":"-84.769668,13.018142,-83.509718,14.052072",
     "geom:latitude":13.492512,
     "geom:longitude":-84.043016,
@@ -112,9 +112,10 @@
         "hasc:id":"NI.AN.PR",
         "wd:id":"Q1018776"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415031,
-    "wof:geomhash":"b378f7ebe1cee991f79f2f96bd114eb2",
+    "wof:geomhash":"112a5b126e9841fe455dd64beab2929e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108693681,
-    "wof:lastmodified":1690848463,
+    "wof:lastmodified":1695886488,
     "wof:name":"Prinzapolka",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/110/869/368/5/1108693685.geojson
+++ b/data/110/869/368/5/1108693685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.374714,
-    "geom:area_square_m":4498168443.090105,
+    "geom:area_square_m":4498168821.353382,
     "geom:bbox":"-85.827567,13.247994,-84.83258,14.579734",
     "geom:latitude":13.874124,
     "geom:longitude":-85.262278,
@@ -176,9 +176,10 @@
         "hasc:id":"NI.JI.EC",
         "wd:id":"Q2214906"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415035,
-    "wof:geomhash":"81bc2aaa2563a85109f38021bbe19d88",
+    "wof:geomhash":"578942ed0661c3902ee307d87dc1d0e5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1108693685,
-    "wof:lastmodified":1690848463,
+    "wof:lastmodified":1695886489,
     "wof:name":"El Cua",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/110/869/368/7/1108693687.geojson
+++ b/data/110/869/368/7/1108693687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04619,
-    "geom:area_square_m":555584976.203098,
+    "geom:area_square_m":555584976.203087,
     "geom:bbox":"-86.0561512134,13.2801894285,-85.768982259,13.5216656515",
     "geom:latitude":13.406083,
     "geom:longitude":-85.91855,
@@ -96,9 +96,10 @@
         "hasc:id":"NI.JI.SM",
         "wd:id":"Q2217474"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415037,
-    "wof:geomhash":"1d31d3c76b77088360b9311db6e0b253",
+    "wof:geomhash":"fb451a7130022976d6d1262a0adc679b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108693687,
-    "wof:lastmodified":1566657007,
+    "wof:lastmodified":1695886489,
     "wof:name":"Las Praderas",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/110/869/368/9/1108693689.geojson
+++ b/data/110/869/368/9/1108693689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032044,
-    "geom:area_square_m":385492606.544116,
+    "geom:area_square_m":385492606.544113,
     "geom:bbox":"-86.257929,13.248949,-86.015366,13.509088",
     "geom:latitude":13.370242,
     "geom:longitude":-86.136443,
@@ -168,9 +168,10 @@
         "hasc:id":"NI.JI.SS",
         "wd:id":"Q2215401"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415039,
-    "wof:geomhash":"e8d657aa8b13e2a77c279da1eb2b14bb",
+    "wof:geomhash":"e66914bb3244640393ef8f4b66e0b550",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1108693689,
-    "wof:lastmodified":1587163112,
+    "wof:lastmodified":1695886287,
     "wof:name":"San Sebastian De Yali",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/110/869/369/1/1108693691.geojson
+++ b/data/110/869/369/1/1108693691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010881,
-    "geom:area_square_m":130994637.715651,
+    "geom:area_square_m":130994400.244539,
     "geom:bbox":"-86.236734,13.107911,-86.126849,13.259061",
     "geom:latitude":13.195023,
     "geom:longitude":-86.17557,
@@ -178,9 +178,10 @@
         "hasc:id":"NI.JI.LC",
         "wd:id":"Q2395382"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415040,
-    "wof:geomhash":"1d38b9d82fad4c7c3204c19d3f0541c0",
+    "wof:geomhash":"5da6da63026accb6ff17d1cf290d618a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":1108693691,
-    "wof:lastmodified":1690848463,
+    "wof:lastmodified":1695886489,
     "wof:name":"La Concordia",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/110/869/369/3/1108693693.geojson
+++ b/data/110/869/369/3/1108693693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01977,
-    "geom:area_square_m":237972486.894938,
+    "geom:area_square_m":237972813.129862,
     "geom:bbox":"-86.167705,13.099078,-86.011293,13.372748",
     "geom:latitude":13.232606,
     "geom:longitude":-86.0902,
@@ -179,9 +179,10 @@
         "hasc:id":"NI.JI.SR",
         "wd:id":"Q2604700"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415042,
-    "wof:geomhash":"491672e744dd47a2efb8140ef28038b8",
+    "wof:geomhash":"52114ed689ac64fd5769c854bd8555c4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1108693693,
-    "wof:lastmodified":1690848463,
+    "wof:lastmodified":1695886489,
     "wof:name":"San Rafael Del Norte",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/110/869/369/5/1108693695.geojson
+++ b/data/110/869/369/5/1108693695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070452,
-    "geom:area_square_m":848240792.079468,
+    "geom:area_square_m":848240441.96845,
     "geom:bbox":"-86.118259,12.995168,-85.721218,13.338618",
     "geom:latitude":13.171293,
     "geom:longitude":-85.929305,
@@ -145,9 +145,10 @@
     "wof:concordances":{
         "hasc:id":"NI.JI.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415043,
-    "wof:geomhash":"807b08fbabcd40452e0575775e1dfaba",
+    "wof:geomhash":"05170f63a047319bb3d34e194f6628ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108693695,
-    "wof:lastmodified":1636503398,
+    "wof:lastmodified":1695886116,
     "wof:name":"Jinotega",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/110/869/369/7/1108693697.geojson
+++ b/data/110/869/369/7/1108693697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037044,
-    "geom:area_square_m":444870846.189201,
+    "geom:area_square_m":444870746.479699,
     "geom:bbox":"-86.061123,13.629385,-85.824854,13.918132",
     "geom:latitude":13.782685,
     "geom:longitude":-85.954214,
@@ -106,9 +106,10 @@
         "hasc:id":"NI.NS.MU",
         "wd:id":"Q2215609"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415045,
-    "wof:geomhash":"e1ad3953d0b416d5f8fbb6a7755f437f",
+    "wof:geomhash":"72f8737df4094ed2a9695d01fadabf5f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108693697,
-    "wof:lastmodified":1690848463,
+    "wof:lastmodified":1695886489,
     "wof:name":"Murra",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/369/9/1108693699.geojson
+++ b/data/110/869/369/9/1108693699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029117,
-    "geom:area_square_m":349980567.79492,
+    "geom:area_square_m":349980578.785753,
     "geom:bbox":"-86.134909,13.466095,-85.886213,13.671394",
     "geom:latitude":13.573088,
     "geom:longitude":-86.0051,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.NS.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415047,
-    "wof:geomhash":"ce95ccc1c99227315c132ade707ad334",
+    "wof:geomhash":"8f5c1222353243a53cdb1c6be6175eba",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693699,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886101,
     "wof:name":"Quilali",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/370/3/1108693703.geojson
+++ b/data/110/869/370/3/1108693703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010603,
-    "geom:area_square_m":127402925.372462,
+    "geom:area_square_m":127402978.960547,
     "geom:bbox":"-86.363593,13.592805,-86.196281,13.717628",
     "geom:latitude":13.645667,
     "geom:longitude":-86.27793,
@@ -100,9 +100,10 @@
         "hasc:id":"NI.NS.CA",
         "wd:id":"Q2215588"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415048,
-    "wof:geomhash":"bf78acc8761c74cff196ef4df9162dbb",
+    "wof:geomhash":"f0c478b1e5d5ee6264ecaf59900f6060",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693703,
-    "wof:lastmodified":1690848460,
+    "wof:lastmodified":1695886487,
     "wof:name":"Ciudad Antigua",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/370/5/1108693705.geojson
+++ b/data/110/869/370/5/1108693705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033878,
-    "geom:area_square_m":406965333.520236,
+    "geom:area_square_m":406965333.520137,
     "geom:bbox":"-86.2472568876,13.5857761953,-86.0117207516,13.845230103",
     "geom:latitude":13.715667,
     "geom:longitude":-86.131194,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"NI.NS.EJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415049,
-    "wof:geomhash":"bcd31b94ccd96a6836951778c370691c",
+    "wof:geomhash":"09b48755cd9d63dc8a623de013c8ae0e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108693705,
-    "wof:lastmodified":1566657002,
+    "wof:lastmodified":1695886487,
     "wof:name":"Ciudad Sandino",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/370/7/1108693707.geojson
+++ b/data/110/869/370/7/1108693707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01871,
-    "geom:area_square_m":224735362.316741,
+    "geom:area_square_m":224735309.688195,
     "geom:bbox":"-86.391317,13.623479,-86.194343,13.846599",
     "geom:latitude":13.738949,
     "geom:longitude":-86.301077,
@@ -110,9 +110,10 @@
         "hasc:id":"NI.NS.SF",
         "wd:id":"Q1647665"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415051,
-    "wof:geomhash":"96662b42a35cb439fbec1b564be438b2",
+    "wof:geomhash":"cfbfb3f9155148ac6b26e638f4736a76",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108693707,
-    "wof:lastmodified":1690848459,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Fernando",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/370/9/1108693709.geojson
+++ b/data/110/869/370/9/1108693709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017001,
-    "geom:area_square_m":204266621.160799,
+    "geom:area_square_m":204266615.872887,
     "geom:bbox":"-86.478966,13.571479,-86.351341,13.77854",
     "geom:latitude":13.67079,
     "geom:longitude":-86.41729,
@@ -107,9 +107,10 @@
         "hasc:id":"NI.NS.MO",
         "wd:id":"Q2215922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415052,
-    "wof:geomhash":"bec590fc9a2a2c1191584f48e08ac258",
+    "wof:geomhash":"6233e073b1bdfeb2842358fffde91dbf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108693709,
-    "wof:lastmodified":1690848459,
+    "wof:lastmodified":1695886487,
     "wof:name":"Mosonte",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/371/1/1108693711.geojson
+++ b/data/110/869/371/1/1108693711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009536,
-    "geom:area_square_m":114548408.152925,
+    "geom:area_square_m":114547958.703521,
     "geom:bbox":"-86.580298,13.658809,-86.465946,13.789973",
     "geom:latitude":13.730584,
     "geom:longitude":-86.521635,
@@ -103,9 +103,10 @@
         "hasc:id":"NI.NS.DI",
         "wd:id":"Q2215450"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415054,
-    "wof:geomhash":"c221ac3bb8129909b70c60f6ec727b90",
+    "wof:geomhash":"7049b3117519d61a77d108c183eb2956",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108693711,
-    "wof:lastmodified":1690848460,
+    "wof:lastmodified":1695886488,
     "wof:name":"Dipilto",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/371/3/1108693713.geojson
+++ b/data/110/869/371/3/1108693713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01018,
-    "geom:area_square_m":122289624.154438,
+    "geom:area_square_m":122289476.917917,
     "geom:bbox":"-86.766783,13.640811,-86.650032,13.780835",
     "geom:latitude":13.720406,
     "geom:longitude":-86.708742,
@@ -116,9 +116,10 @@
         "hasc:id":"NI.NS.SM",
         "wd:id":"Q1647660"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415055,
-    "wof:geomhash":"a0dcc7017e134453da87b35dcc380748",
+    "wof:geomhash":"3d2114ed297b135188d9b12972a3ddc4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108693713,
-    "wof:lastmodified":1690848460,
+    "wof:lastmodified":1695886116,
     "wof:name":"Santa Maria",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/371/5/1108693715.geojson
+++ b/data/110/869/371/5/1108693715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021281,
-    "geom:area_square_m":255684715.081264,
+    "geom:area_square_m":255685132.455522,
     "geom:bbox":"-86.702677,13.569236,-86.507548,13.782441",
     "geom:latitude":13.674854,
     "geom:longitude":-86.602505,
@@ -103,9 +103,10 @@
         "hasc:id":"NI.NS.MA",
         "wd:id":"Q1647684"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415057,
-    "wof:geomhash":"86ffa4b646f88e6d4320d64da4941d7d",
+    "wof:geomhash":"172d3d196aa043e02781884a3037e792",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108693715,
-    "wof:lastmodified":1690848461,
+    "wof:lastmodified":1695886488,
     "wof:name":"Macuelizo",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/110/869/371/7/1108693717.geojson
+++ b/data/110/869/371/7/1108693717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01353,
-    "geom:area_square_m":162645266.433838,
+    "geom:area_square_m":162645602.404691,
     "geom:bbox":"-86.572345,13.491251,-86.352375,13.595471",
     "geom:latitude":13.549216,
     "geom:longitude":-86.463387,
@@ -119,9 +119,10 @@
         "hasc:id":"NI.MD.TO",
         "wd:id":"Q2216999"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415060,
-    "wof:geomhash":"b63cf290813ff37ccf2a433d773f824b",
+    "wof:geomhash":"f0ecae2a0f29a91aeab975cb115d92cd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108693717,
-    "wof:lastmodified":1690848460,
+    "wof:lastmodified":1695886488,
     "wof:name":"Totolgalpa",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/372/1/1108693721.geojson
+++ b/data/110/869/372/1/1108693721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016006,
-    "geom:area_square_m":192428624.279772,
+    "geom:area_square_m":192428740.679759,
     "geom:bbox":"-86.223363,13.437625,-86.069743,13.612023",
     "geom:latitude":13.52345,
     "geom:longitude":-86.148032,
@@ -102,9 +102,10 @@
         "hasc:id":"NI.MD.SR",
         "wd:id":"Q1647654"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415062,
-    "wof:geomhash":"197962840754bead8219aa401b58741f",
+    "wof:geomhash":"7f5214ce48c56a51af4ae49f66788633",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108693721,
-    "wof:lastmodified":1690848469,
+    "wof:lastmodified":1695886491,
     "wof:name":"San Juan Del Rio Coco",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/372/3/1108693723.geojson
+++ b/data/110/869/372/3/1108693723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029223,
-    "geom:area_square_m":351338918.520283,
+    "geom:area_square_m":351338212.278471,
     "geom:bbox":"-86.386162,13.396349,-86.177233,13.623078",
     "geom:latitude":13.515305,
     "geom:longitude":-86.270887,
@@ -103,9 +103,10 @@
         "hasc:id":"NI.MD.TE",
         "wd:id":"Q2216981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415063,
-    "wof:geomhash":"9fb0a033914ba00e9600427b6338e1dd",
+    "wof:geomhash":"145b6129861d71d198b41d493998f892",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108693723,
-    "wof:lastmodified":1690848469,
+    "wof:lastmodified":1695886491,
     "wof:name":"Telpaneca",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/372/5/1108693725.geojson
+++ b/data/110/869/372/5/1108693725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013101,
-    "geom:area_square_m":157551874.676096,
+    "geom:area_square_m":157551744.508623,
     "geom:bbox":"-86.478104,13.398887,-86.297416,13.515705",
     "geom:latitude":13.449558,
     "geom:longitude":-86.398199,
@@ -113,9 +113,10 @@
         "hasc:id":"NI.MD.PA",
         "wd:id":"Q2215620"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415064,
-    "wof:geomhash":"c663ffdaf02f62258b041ebe67cb7582",
+    "wof:geomhash":"41eee11d1dcdd8026e38c309a914c560",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108693725,
-    "wof:lastmodified":1690848469,
+    "wof:lastmodified":1695886491,
     "wof:name":"Palacaguina",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/372/7/1108693727.geojson
+++ b/data/110/869/372/7/1108693727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005795,
-    "geom:area_square_m":69684051.874574,
+    "geom:area_square_m":69683906.127292,
     "geom:bbox":"-86.534356,13.413596,-86.442551,13.526035",
     "geom:latitude":13.475292,
     "geom:longitude":-86.49447,
@@ -110,9 +110,10 @@
         "hasc:id":"NI.MD.YA",
         "wd:id":"Q2216994"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415066,
-    "wof:geomhash":"0f92dae867588e3c9fdd8562b18a90de",
+    "wof:geomhash":"a842f36155b72cc6a8b52c782cba377b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108693727,
-    "wof:lastmodified":1690848469,
+    "wof:lastmodified":1695886491,
     "wof:name":"Yalaguina",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/372/9/1108693729.geojson
+++ b/data/110/869/372/9/1108693729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012013,
-    "geom:area_square_m":144497157.655828,
+    "geom:area_square_m":144497106.553902,
     "geom:bbox":"-86.739332,13.347165,-86.558427,13.445851",
     "geom:latitude":13.400739,
     "geom:longitude":-86.653928,
@@ -109,9 +109,10 @@
         "hasc:id":"NI.MD.SL",
         "wd:id":"Q1647851"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415067,
-    "wof:geomhash":"21e2c87586a74066e189ad5930e3279e",
+    "wof:geomhash":"0b8e551e23e12b7f47f7eab2c4b5350a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108693729,
-    "wof:lastmodified":1690848468,
+    "wof:lastmodified":1695886491,
     "wof:name":"San Lucas",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/373/1/1108693731.geojson
+++ b/data/110/869/373/1/1108693731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00543,
-    "geom:area_square_m":65329238.276724,
+    "geom:area_square_m":65329238.785807,
     "geom:bbox":"-86.707978,13.301889,-86.588788,13.376391",
     "geom:latitude":13.338268,
     "geom:longitude":-86.647413,
@@ -109,9 +109,10 @@
         "hasc:id":"NI.MD.LS",
         "wd:id":"Q2215117"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415069,
-    "wof:geomhash":"28b8fc918ee907978f55508894054712",
+    "wof:geomhash":"04be7aa22863689ec1e0b16aa0f83dca",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108693731,
-    "wof:lastmodified":1690848465,
+    "wof:lastmodified":1695886489,
     "wof:name":"Las Sabanas",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/373/3/1108693733.geojson
+++ b/data/110/869/373/3/1108693733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00967,
-    "geom:area_square_m":116378769.720071,
+    "geom:area_square_m":116378769.72005,
     "geom:bbox":"-86.7708812162,13.1865876004,-86.6172629742,13.3202420302",
     "geom:latitude":13.260592,
     "geom:longitude":-86.680629,
@@ -93,9 +93,10 @@
         "hasc:id":"NI.MD.SC",
         "wd:id":"Q2215949"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415071,
-    "wof:geomhash":"3770f556d8c9c780dc87244ed4933ab3",
+    "wof:geomhash":"2c17161470e09aef57ce661b1ee76fe8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108693733,
-    "wof:lastmodified":1566657009,
+    "wof:lastmodified":1695886489,
     "wof:name":"San Jose De Cusmapa",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/110/869/373/5/1108693735.geojson
+++ b/data/110/869/373/5/1108693735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004523,
-    "geom:area_square_m":54436704.497524,
+    "geom:area_square_m":54436717.615019,
     "geom:bbox":"-86.909981,13.232405,-86.77553,13.300735",
     "geom:latitude":13.270617,
     "geom:longitude":-86.840983,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CI.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415072,
-    "wof:geomhash":"10664024130caf96904df294cdfbf93a",
+    "wof:geomhash":"c05d4c81b39732fd5d52f72f7a0a132c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108693735,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886101,
     "wof:name":"San Pedro Del Norte",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/110/869/373/9/1108693739.geojson
+++ b/data/110/869/373/9/1108693739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010194,
-    "geom:area_square_m":122711950.930751,
+    "geom:area_square_m":122711470.855035,
     "geom:bbox":"-86.831259,13.146499,-86.702518,13.280597",
     "geom:latitude":13.211166,
     "geom:longitude":-86.773238,
@@ -107,9 +107,10 @@
         "hasc:id":"NI.CI.SF",
         "wd:id":"Q2214920"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415073,
-    "wof:geomhash":"9e0735c98c0a76f61e087fc486a895d6",
+    "wof:geomhash":"05bba4ee6910897fda8e7add68acdb3b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108693739,
-    "wof:lastmodified":1690848464,
+    "wof:lastmodified":1695886489,
     "wof:name":"San Fco. Del Norte",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/110/869/374/1/1108693741.geojson
+++ b/data/110/869/374/1/1108693741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003082,
-    "geom:area_square_m":37104642.498676,
+    "geom:area_square_m":37104786.986928,
     "geom:bbox":"-86.926656,13.137857,-86.869762,13.218315",
     "geom:latitude":13.176739,
     "geom:longitude":-86.897051,
@@ -96,9 +96,10 @@
         "hasc:id":"NI.CI.SP",
         "wd:id":"Q2216439"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415076,
-    "wof:geomhash":"ad3a146efd4446fabc9bff85bd4e49cb",
+    "wof:geomhash":"b3b45ad5ebdbfcaa9f485a93fa51dca9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108693741,
-    "wof:lastmodified":1690848467,
+    "wof:lastmodified":1695886490,
     "wof:name":"San Pedro Del Norte",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/110/869/374/3/1108693743.geojson
+++ b/data/110/869/374/3/1108693743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067766,
-    "geom:area_square_m":816769363.542218,
+    "geom:area_square_m":816769502.657996,
     "geom:bbox":"-86.948135,12.743717,-86.661735,13.144128",
     "geom:latitude":12.906066,
     "geom:longitude":-86.793337,
@@ -157,9 +157,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CI.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415078,
-    "wof:geomhash":"15bc8294412284bc43472a993e17d932",
+    "wof:geomhash":"6b82bc8078c485ae57314430f5afa6ea",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108693743,
-    "wof:lastmodified":1636503398,
+    "wof:lastmodified":1695886116,
     "wof:name":"Villanueva",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/110/869/374/5/1108693745.geojson
+++ b/data/110/869/374/5/1108693745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020464,
-    "geom:area_square_m":246737272.451465,
+    "geom:area_square_m":246736421.322614,
     "geom:bbox":"-87.326702,12.71162,-87.109272,12.915218",
     "geom:latitude":12.818107,
     "geom:longitude":-87.209103,
@@ -116,9 +116,10 @@
         "hasc:id":"NI.CI.PM",
         "wd:id":"Q2605034"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415080,
-    "wof:geomhash":"039ae9298d12aac3fc6f90006448e895",
+    "wof:geomhash":"f336c01aa5087feaf5292692a33a411e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108693745,
-    "wof:lastmodified":1690848467,
+    "wof:lastmodified":1695886490,
     "wof:name":"Tonala",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/110/869/374/7/1108693747.geojson
+++ b/data/110/869/374/7/1108693747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008129,
-    "geom:area_square_m":98112241.648876,
+    "geom:area_square_m":98112722.234583,
     "geom:bbox":"-87.249288,12.498864,-87.12079,12.612606",
     "geom:latitude":12.554979,
     "geom:longitude":-87.184076,
@@ -112,9 +112,10 @@
         "hasc:id":"NI.CI.ER",
         "wd:id":"Q368227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415083,
-    "wof:geomhash":"9f4c5027d709ceb71767e39763c80744",
+    "wof:geomhash":"5900404f8d60cbc08fa35a3b53ba2169",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108693747,
-    "wof:lastmodified":1690848467,
+    "wof:lastmodified":1695886490,
     "wof:name":"El Realejo",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/110/869/374/9/1108693749.geojson
+++ b/data/110/869/374/9/1108693749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011213,
-    "geom:area_square_m":135313080.005652,
+    "geom:area_square_m":135313132.23387,
     "geom:bbox":"-87.008715,12.503774,-86.87534,12.677817",
     "geom:latitude":12.600297,
     "geom:longitude":-86.950376,
@@ -115,9 +115,10 @@
         "hasc:id":"NI.CI.PO",
         "wd:id":"Q2604656"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415086,
-    "wof:geomhash":"e9d069f4c55522247153658e0358e40c",
+    "wof:geomhash":"4e62e420f672b2ccc987d16fa819605c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108693749,
-    "wof:lastmodified":1690848467,
+    "wof:lastmodified":1695886490,
     "wof:name":"Posoltega",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/110/869/375/1/1108693751.geojson
+++ b/data/110/869/375/1/1108693751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034979,
-    "geom:area_square_m":421111567.864237,
+    "geom:area_square_m":421111479.557982,
     "geom:bbox":"-86.750041,13.098529,-86.45362,13.301889",
     "geom:latitude":13.189494,
     "geom:longitude":-86.594513,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.ES.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415089,
-    "wof:geomhash":"588328ea6a42c5ad64fdb6f4e9acae52",
+    "wof:geomhash":"8fafa1405703fde63f470ae630019c01",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693751,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886101,
     "wof:name":"San Juan De Limay",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/110/869/375/3/1108693753.geojson
+++ b/data/110/869/375/3/1108693753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067247,
-    "geom:area_square_m":809771800.983672,
+    "geom:area_square_m":809771826.453723,
     "geom:bbox":"-86.504575,12.963361,-86.168943,13.29054",
     "geom:latitude":13.132142,
     "geom:longitude":-86.343246,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.ES.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415090,
-    "wof:geomhash":"767a2bac2ba390878606eee37c58c5be",
+    "wof:geomhash":"4615f5d3f2b7733f1caca971c4b36380",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693753,
-    "wof:lastmodified":1627522476,
+    "wof:lastmodified":1695886101,
     "wof:name":"Esteli",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/110/869/375/7/1108693757.geojson
+++ b/data/110/869/375/7/1108693757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021925,
-    "geom:area_square_m":264147737.989247,
+    "geom:area_square_m":264147301.863123,
     "geom:bbox":"-86.319278,12.910004,-86.096843,13.108079",
     "geom:latitude":13.012083,
     "geom:longitude":-86.211036,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"NI.ES.LT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415092,
-    "wof:geomhash":"d502c10ff2be3a3ec21702949a894498",
+    "wof:geomhash":"0d86f06b03fbb86a3d05da84717761e0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693757,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"La Trinidad",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/110/869/375/9/1108693759.geojson
+++ b/data/110/869/375/9/1108693759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013287,
-    "geom:area_square_m":160139559.018797,
+    "geom:area_square_m":160139848.774805,
     "geom:bbox":"-86.439496,12.850431,-86.285916,12.98672",
     "geom:latitude":12.921405,
     "geom:longitude":-86.362924,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.ES.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415093,
-    "wof:geomhash":"06e79f1205ac5bfb8914c087608ac3ff",
+    "wof:geomhash":"4045f1db43cbfa5141f1f953e43d2068",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693759,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"San Nicolas",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/110/869/376/1/1108693761.geojson
+++ b/data/110/869/376/1/1108693761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032209,
-    "geom:area_square_m":387987601.046673,
+    "geom:area_square_m":387987191.291331,
     "geom:bbox":"-86.739279,12.958984,-86.469579,13.127306",
     "geom:latitude":13.050871,
     "geom:longitude":-86.602568,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"NI.LE.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415095,
-    "wof:geomhash":"d927bd53b0f09f03df13595ddb37058d",
+    "wof:geomhash":"78290948471dfc0c2225b5a47a615660",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108693761,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"Achuapa",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/110/869/376/3/1108693763.geojson
+++ b/data/110/869/376/3/1108693763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01843,
-    "geom:area_square_m":222205842.181358,
+    "geom:area_square_m":222206040.358695,
     "geom:bbox":"-86.456467,12.734209,-86.283554,12.898223",
     "geom:latitude":12.817502,
     "geom:longitude":-86.367738,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.LE.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415097,
-    "wof:geomhash":"0ddcc645788f7789cda18b95badcfcc4",
+    "wof:geomhash":"defd885ae89b63df699c7520da644196",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693763,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"Santa Rosa Del Penon",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/110/869/376/5/1108693765.geojson
+++ b/data/110/869/376/5/1108693765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036444,
-    "geom:area_square_m":439721357.715822,
+    "geom:area_square_m":439721357.715897,
     "geom:bbox":"-86.4736343022,12.4567482899,-86.2758356673,12.7974987223",
     "geom:latitude":12.638784,
     "geom:longitude":-86.386333,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"NI.LE.EJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415099,
-    "wof:geomhash":"8822ccaea3dbfbc64451c8dc696c8530",
+    "wof:geomhash":"d6a20e31591cacc50afcc1a26369bb40",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693765,
-    "wof:lastmodified":1566657005,
+    "wof:lastmodified":1695886488,
     "wof:name":"El Jicaral",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/110/869/376/7/1108693767.geojson
+++ b/data/110/869/376/7/1108693767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062876,
-    "geom:area_square_m":758610049.796261,
+    "geom:area_square_m":758610589.055285,
     "geom:bbox":"-86.788043,12.494221,-86.438545,12.792049",
     "geom:latitude":12.647578,
     "geom:longitude":-86.617989,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NI.LE.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415100,
-    "wof:geomhash":"8d7710297d8a64cb91eb1e9cb9802542",
+    "wof:geomhash":"3dc9f31e454898d031a1168d824e1d8b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108693767,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"Malpaisillo",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/110/869/376/9/1108693769.geojson
+++ b/data/110/869/376/9/1108693769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069545,
-    "geom:area_square_m":839892685.333484,
+    "geom:area_square_m":839892685.333501,
     "geom:bbox":"-87.1108857359,12.1992558651,-86.6757240626,12.5231136385",
     "geom:latitude":12.396194,
     "geom:longitude":-86.873268,
@@ -116,9 +116,10 @@
     "wof:concordances":{
         "hasc:id":"NI.LE.LE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415104,
-    "wof:geomhash":"3f549696912613d3f149ad488414e638",
+    "wof:geomhash":"3350b6d9b1a73e8d18093caaf3654abb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108693769,
-    "wof:lastmodified":1566657004,
+    "wof:lastmodified":1695886488,
     "wof:name":"Isla",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/110/869/377/1/1108693771.geojson
+++ b/data/110/869/377/1/1108693771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056537,
-    "geom:area_square_m":682749255.715827,
+    "geom:area_square_m":682749255.715816,
     "geom:bbox":"-86.7844184717,12.223686839,-86.4108105117,12.5600618745",
     "geom:latitude":12.41266,
     "geom:longitude":-86.613943,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"NI.LE.LP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415105,
-    "wof:geomhash":"c216d4a01206f62723a58a651272f5b2",
+    "wof:geomhash":"54804103ffa151ae21e6dac964ca7957",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108693771,
-    "wof:lastmodified":1566657001,
+    "wof:lastmodified":1695886487,
     "wof:name":"La Paz Centro",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/110/869/377/5/1108693775.geojson
+++ b/data/110/869/377/5/1108693775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056941,
-    "geom:area_square_m":687409002.024133,
+    "geom:area_square_m":687408632.999955,
     "geom:bbox":"-86.380971,12.272205,-86.100572,12.641778",
     "geom:latitude":12.494652,
     "geom:longitude":-86.222189,
@@ -109,9 +109,10 @@
         "hasc:id":"NI.MN.SF",
         "wd:id":"Q427811"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415107,
-    "wof:geomhash":"c3e661d04ab935cc12bfa91d8da30a04",
+    "wof:geomhash":"587b0a3958df92e676e873a5b0717ff7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108693775,
-    "wof:lastmodified":1690848459,
+    "wof:lastmodified":1695886487,
     "wof:name":"San Francisco Libre",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/110/869/377/7/1108693777.geojson
+++ b/data/110/869/377/7/1108693777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04753,
-    "geom:area_square_m":574832223.586169,
+    "geom:area_square_m":574832002.220094,
     "geom:bbox":"-86.673614,11.866461,-86.361435,12.158597",
     "geom:latitude":12.02118,
     "geom:longitude":-86.528278,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NI.MN.VC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415112,
-    "wof:geomhash":"7fa90512f8a25339cd467b20b8ee8510",
+    "wof:geomhash":"8dd0536fb14ad98eeb1204311f1e059f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108693777,
-    "wof:lastmodified":1627522478,
+    "wof:lastmodified":1695886102,
     "wof:name":"Villa Carlos Fonseca A",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/110/869/377/9/1108693779.geojson
+++ b/data/110/869/377/9/1108693779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031192,
-    "geom:area_square_m":377474567.296031,
+    "geom:area_square_m":377474353.900953,
     "geom:bbox":"-86.586134,11.715189,-86.327588,11.951035",
     "geom:latitude":11.851165,
     "geom:longitude":-86.458143,
@@ -122,9 +122,10 @@
         "hasc:id":"NI.MN.SR",
         "wd:id":"Q964406"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415114,
-    "wof:geomhash":"d6d49084301f42bd3cc470cd1b5d03e7",
+    "wof:geomhash":"b116a51e5aaf01723836493086bfab3f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108693779,
-    "wof:lastmodified":1690848459,
+    "wof:lastmodified":1695886487,
     "wof:name":"San Rafael Del Sur",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/110/869/378/1/1108693781.geojson
+++ b/data/110/869/378/1/1108693781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010203,
-    "geom:area_square_m":123365223.11837,
+    "geom:area_square_m":123364204.890808,
     "geom:bbox":"-86.069081,12.014227,-85.961348,12.151979",
     "geom:latitude":12.086136,
     "geom:longitude":-86.019791,
@@ -103,9 +103,10 @@
         "hasc:id":"NI.MS.TI",
         "wd:id":"Q2216452"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415116,
-    "wof:geomhash":"0383e3eefe1f0e7ebc742814eddf74a8",
+    "wof:geomhash":"9de4ae3e4d5241197b1b2cbf67959bea",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108693781,
-    "wof:lastmodified":1690848462,
+    "wof:lastmodified":1695886488,
     "wof:name":"Tisma",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/110/869/378/3/1108693783.geojson
+++ b/data/110/869/378/3/1108693783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012272,
-    "geom:area_square_m":148404634.659107,
+    "geom:area_square_m":148404765.572819,
     "geom:bbox":"-86.204989,11.962739,-86.089827,12.142373",
     "geom:latitude":12.046151,
     "geom:longitude":-86.137438,
@@ -119,9 +119,10 @@
         "hasc:id":"NI.MS.NN",
         "wd:id":"Q2215135"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415117,
-    "wof:geomhash":"daf1d7335b4e328b65ffc595032963dd",
+    "wof:geomhash":"f926c28ddcc5893242fe80e451c6a385",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108693783,
-    "wof:lastmodified":1690848462,
+    "wof:lastmodified":1695886489,
     "wof:name":"Nindiri",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/110/869/378/5/1108693785.geojson
+++ b/data/110/869/378/5/1108693785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006141,
-    "geom:area_square_m":74293148.003025,
+    "geom:area_square_m":74293170.801979,
     "geom:bbox":"-86.297616,11.920256,-86.151036,11.99272",
     "geom:latitude":11.954953,
     "geom:longitude":-86.22222,
@@ -110,9 +110,10 @@
         "hasc:id":"NI.MS.LC",
         "wd:id":"Q538269"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415120,
-    "wof:geomhash":"e7a359168938fa81e4607d89e8b5002e",
+    "wof:geomhash":"6f5ac5b14f0adefc8abd98da661d8d36",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108693785,
-    "wof:lastmodified":1690848462,
+    "wof:lastmodified":1695886489,
     "wof:name":"La Concepcion",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/110/869/378/7/1108693787.geojson
+++ b/data/110/869/378/7/1108693787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000761,
-    "geom:area_square_m":9203862.844525,
+    "geom:area_square_m":9203787.965866,
     "geom:bbox":"-86.087042,11.878458,-86.048498,11.914425",
     "geom:latitude":11.899286,
     "geom:longitude":-86.069061,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.MS.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415123,
-    "wof:geomhash":"c13d1e226b87f4872fcdd39ec30c663b",
+    "wof:geomhash":"ea94ec1de33a3599a9b2d68acd539c04",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693787,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"San Juan De Oriente",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/110/869/378/9/1108693789.geojson
+++ b/data/110/869/378/9/1108693789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00804,
-    "geom:area_square_m":97275938.125865,
+    "geom:area_square_m":97275533.902347,
     "geom:bbox":"-86.379255,11.815607,-86.203226,11.954602",
     "geom:latitude":11.89721,
     "geom:longitude":-86.295761,
@@ -142,9 +142,10 @@
         "hasc:id":"NI.CA.SM",
         "wd:id":"Q1013654"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415126,
-    "wof:geomhash":"1cdb6c42cb4d56c7d3348bd2e76aef0f",
+    "wof:geomhash":"c33e8543de790cd1f567ec868e89e05a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108693789,
-    "wof:lastmodified":1690848461,
+    "wof:lastmodified":1695886116,
     "wof:name":"San Marcos",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/110/869/379/3/1108693793.geojson
+++ b/data/110/869/379/3/1108693793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03256,
-    "geom:area_square_m":394141085.977639,
+    "geom:area_square_m":394141085.977603,
     "geom:bbox":"-86.4526836496,11.6442152413,-86.1711007251,11.9247317621",
     "geom:latitude":11.774745,
     "geom:longitude":-86.324151,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CA.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415127,
-    "wof:geomhash":"7cea53afc2f3558500d056270492bb4d",
+    "wof:geomhash":"8ae050dad90221069fdaaab8a42e94e9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693793,
-    "wof:lastmodified":1566656999,
+    "wof:lastmodified":1695886487,
     "wof:name":"Diriamba",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/110/869/379/5/1108693795.geojson
+++ b/data/110/869/379/5/1108693795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003446,
-    "geom:area_square_m":41709226.642756,
+    "geom:area_square_m":41709129.160543,
     "geom:bbox":"-86.270001,11.689712,-86.20377,11.854525",
     "geom:latitude":11.776042,
     "geom:longitude":-86.237188,
@@ -133,9 +133,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CA.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415129,
-    "wof:geomhash":"31b7f6d77bab59e90452fd4eae024b56",
+    "wof:geomhash":"127b6e467990243c4c6fb8c769fa287e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108693795,
-    "wof:lastmodified":1636503396,
+    "wof:lastmodified":1695886115,
     "wof:name":"Dolores",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/110/869/379/7/1108693797.geojson
+++ b/data/110/869/379/7/1108693797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007323,
-    "geom:area_square_m":88661662.067513,
+    "geom:area_square_m":88661725.974071,
     "geom:bbox":"-86.221791,11.62509,-86.148622,11.817827",
     "geom:latitude":11.713758,
     "geom:longitude":-86.186029,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CA.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415131,
-    "wof:geomhash":"c2df0ceee6e4a8a4ebf13bf7862fd2cc",
+    "wof:geomhash":"fb7510b0f1f7eb4c953b19e671f07f07",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108693797,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"La Conquista",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/110/869/379/9/1108693799.geojson
+++ b/data/110/869/379/9/1108693799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001757,
-    "geom:area_square_m":21268080.648951,
+    "geom:area_square_m":21268080.648933,
     "geom:bbox":"-86.1785761872,11.8051330971,-86.1161338473,11.8567693004",
     "geom:latitude":11.829216,
     "geom:longitude":-86.150875,
@@ -106,9 +106,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CA.ER"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415133,
-    "wof:geomhash":"a2c404e980d17eb970c46b82943ba450",
+    "wof:geomhash":"65a86af0034cb78bed82a524abacf970",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108693799,
-    "wof:lastmodified":1566656999,
+    "wof:lastmodified":1695886487,
     "wof:name":"El Rosario",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/110/869/380/1/1108693801.geojson
+++ b/data/110/869/380/1/1108693801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001744,
-    "geom:area_square_m":21111317.958338,
+    "geom:area_square_m":21111317.958344,
     "geom:bbox":"-86.1415421985,11.7901108812,-86.077574787,11.835559003",
     "geom:latitude":11.812988,
     "geom:longitude":-86.107618,
@@ -93,9 +93,10 @@
         "hasc:id":"NI.CA.LP",
         "wd:id":"Q2215549"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415134,
-    "wof:geomhash":"63ed3b73162d28d343694f4e7cc35c99",
+    "wof:geomhash":"5036fbd7638e82557544a3de8cb57f16",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108693801,
-    "wof:lastmodified":1566657010,
+    "wof:lastmodified":1695886490,
     "wof:name":"La Paz De Carazo",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/110/869/380/3/1108693803.geojson
+++ b/data/110/869/380/3/1108693803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017853,
-    "geom:area_square_m":216196019.015196,
+    "geom:area_square_m":216196523.60376,
     "geom:bbox":"-86.217078,11.514449,-86.085427,11.814759",
     "geom:latitude":11.661146,
     "geom:longitude":-86.151091,
@@ -95,9 +95,10 @@
         "hasc:id":"NI.CA.DI",
         "wd:id":"Q2216587"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415136,
-    "wof:geomhash":"56379845775d2d9a0d2559a956070d1f",
+    "wof:geomhash":"82ad454e0ff1333df1486c5b895511dd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108693803,
-    "wof:lastmodified":1690848466,
+    "wof:lastmodified":1695886490,
     "wof:name":"Diriamba",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/110/869/380/5/1108693805.geojson
+++ b/data/110/869/380/5/1108693805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001967,
-    "geom:area_square_m":23806070.273096,
+    "geom:area_square_m":23806204.983854,
     "geom:bbox":"-86.108293,11.810131,-86.003591,11.908334",
     "geom:latitude":11.856984,
     "geom:longitude":-86.068045,
@@ -113,9 +113,10 @@
         "hasc:id":"NI.GR.DA",
         "wd:id":"Q1647847"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415138,
-    "wof:geomhash":"b200fc23a037c7f293456b7b32cff472",
+    "wof:geomhash":"1271dc70b34848f5bf81e5cddcc774c6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108693805,
-    "wof:lastmodified":1690848466,
+    "wof:lastmodified":1695886490,
     "wof:name":"Diria",
     "wof:parent_id":85675477,
     "wof:placetype":"county",

--- a/data/110/869/380/7/1108693807.geojson
+++ b/data/110/869/380/7/1108693807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002515,
-    "geom:area_square_m":30427503.80962,
+    "geom:area_square_m":30427503.809596,
     "geom:bbox":"-86.1174510909,11.834025489,-86.0741674932,11.9249004072",
     "geom:latitude":11.875383,
     "geom:longitude":-86.098434,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"NI.MS.NQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415141,
-    "wof:geomhash":"5206e11d8c3bb9f2f1f9c843c3cf58ad",
+    "wof:geomhash":"13fd5e2898a6887d3d13ea3cb1f8c8e4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693807,
-    "wof:lastmodified":1566657010,
+    "wof:lastmodified":1695886490,
     "wof:name":"Niquinohomo",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/110/869/381/1/1108693811.geojson
+++ b/data/110/869/381/1/1108693811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020432,
-    "geom:area_square_m":247520173.647825,
+    "geom:area_square_m":247520523.621008,
     "geom:bbox":"-86.137983,11.448363,-85.849804,11.655729",
     "geom:latitude":11.558612,
     "geom:longitude":-85.9707,
@@ -134,9 +134,10 @@
     "wof:concordances":{
         "hasc:id":"NI.RI.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415143,
-    "wof:geomhash":"a24460431878cbda41bf7808ae4a6999",
+    "wof:geomhash":"bc9fe2217b3d370af456029e1d6071b9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108693811,
-    "wof:lastmodified":1636503398,
+    "wof:lastmodified":1695886116,
     "wof:name":"Belen",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/110/869/381/3/1108693813.geojson
+++ b/data/110/869/381/3/1108693813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011539,
-    "geom:area_square_m":139780836.260637,
+    "geom:area_square_m":139781105.362408,
     "geom:bbox":"-85.969414,11.458491,-85.828752,11.682673",
     "geom:latitude":11.579891,
     "geom:longitude":-85.890886,
@@ -113,9 +113,10 @@
         "hasc:id":"NI.RI.PO",
         "wd:id":"Q1647911"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415145,
-    "wof:geomhash":"482e900ed80588db5fd3041a2c51aff5",
+    "wof:geomhash":"ae808f6baaa7636b066eeca27d8269ef",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108693813,
-    "wof:lastmodified":1690848468,
+    "wof:lastmodified":1695886490,
     "wof:name":"Potosi",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/110/869/381/7/1108693817.geojson
+++ b/data/110/869/381/7/1108693817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050798,
-    "geom:area_square_m":611497349.454526,
+    "geom:area_square_m":611497867.771072,
     "geom:bbox":"-85.655551,13.083583,-85.298801,13.34859",
     "geom:latitude":13.210927,
     "geom:longitude":-85.495037,
@@ -97,9 +97,10 @@
         "hasc:id":"NI.MT.RG",
         "wd:id":"Q2215071"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415153,
-    "wof:geomhash":"c1728d1818b7191a019e6386904e2182",
+    "wof:geomhash":"9ed6a9af11c61157d2ec4259bb9817df",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108693817,
-    "wof:lastmodified":1690848468,
+    "wof:lastmodified":1695886490,
     "wof:name":"Rancho Grande",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/381/9/1108693819.geojson
+++ b/data/110/869/381/9/1108693819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054109,
-    "geom:area_square_m":651629661.688772,
+    "geom:area_square_m":651629561.391459,
     "geom:bbox":"-85.839246,12.958651,-85.520556,13.269032",
     "geom:latitude":13.109037,
     "geom:longitude":-85.688204,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"NI.MT.TD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415155,
-    "wof:geomhash":"6a044b45ed25282dd544d69de8fcc745",
+    "wof:geomhash":"1021121a75851b0a0f08433f9c35e062",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108693819,
-    "wof:lastmodified":1627522476,
+    "wof:lastmodified":1695886101,
     "wof:name":"La Dalia",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/382/1/1108693821.geojson
+++ b/data/110/869/382/1/1108693821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023028,
-    "geom:area_square_m":277545299.956152,
+    "geom:area_square_m":277545434.48436,
     "geom:bbox":"-86.174164,12.799322,-85.976171,13.041293",
     "geom:latitude":12.912286,
     "geom:longitude":-86.083744,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.MT.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415157,
-    "wof:geomhash":"aa97f0f883ba6f832c15a6dfdcab6fdb",
+    "wof:geomhash":"18806ba7efbb2758136693b29d54bcd1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693821,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"Sebaco",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/382/3/1108693823.geojson
+++ b/data/110/869/382/3/1108693823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024613,
-    "geom:area_square_m":296694637.264707,
+    "geom:area_square_m":296694624.327841,
     "geom:bbox":"-86.293759,12.740679,-86.105394,12.991406",
     "geom:latitude":12.873242,
     "geom:longitude":-86.210996,
@@ -140,9 +140,10 @@
         "hasc:id":"NI.MT.CD",
         "wd:id":"Q1015865"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415158,
-    "wof:geomhash":"527f5172a1f36cfe9f8ed15f68853e23",
+    "wof:geomhash":"24018d826628ffaf359a12fa906d370c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108693823,
-    "wof:lastmodified":1690848461,
+    "wof:lastmodified":1695886488,
     "wof:name":"Ciudad Dario",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/382/5/1108693825.geojson
+++ b/data/110/869/382/5/1108693825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013869,
-    "geom:area_square_m":167257974.569513,
+    "geom:area_square_m":167258719.769602,
     "geom:bbox":"-85.938287,12.691652,-85.771127,12.855366",
     "geom:latitude":12.765586,
     "geom:longitude":-85.859367,
@@ -103,9 +103,10 @@
         "hasc:id":"NI.MT.SD",
         "wd:id":"Q1647872"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415161,
-    "wof:geomhash":"681c7d80592bf19655fa32d4af6441c9",
+    "wof:geomhash":"9459c92f764d0aa629c382ee8cd785ce",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108693825,
-    "wof:lastmodified":1690848461,
+    "wof:lastmodified":1695886488,
     "wof:name":"San Dionisio",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/382/9/1108693829.geojson
+++ b/data/110/869/382/9/1108693829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017758,
-    "geom:area_square_m":214212002.907976,
+    "geom:area_square_m":214212002.907977,
     "geom:bbox":"-85.8891102491,12.6355386652,-85.6335647848,12.7753632763",
     "geom:latitude":12.691985,
     "geom:longitude":-85.767957,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"NI.MT.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415163,
-    "wof:geomhash":"9be8fe7ef2293378827b03f8e8b901ff",
+    "wof:geomhash":"40eaed60f0f84daacffe7676cdd4731a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693829,
-    "wof:lastmodified":1566657005,
+    "wof:lastmodified":1695886488,
     "wof:name":"Esquipulas",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/383/1/1108693831.geojson
+++ b/data/110/869/383/1/1108693831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034902,
-    "geom:area_square_m":420644660.543414,
+    "geom:area_square_m":420644931.894828,
     "geom:bbox":"-85.87514,12.819006,-85.594398,13.013852",
     "geom:latitude":12.919161,
     "geom:longitude":-85.733381,
@@ -128,9 +128,10 @@
         "hasc:id":"NI.MT.SR",
         "wd:id":"Q2395748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415165,
-    "wof:geomhash":"b85414c47d315f106158a493355a07a1",
+    "wof:geomhash":"4fc66da969bf50a24774ae15523eb2ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108693831,
-    "wof:lastmodified":1690848458,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Ramon",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/383/3/1108693833.geojson
+++ b/data/110/869/383/3/1108693833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130519,
-    "geom:area_square_m":1573338674.92952,
+    "geom:area_square_m":1573337834.188145,
     "geom:bbox":"-85.639641,12.610008,-85.121392,13.097422",
     "geom:latitude":12.870829,
     "geom:longitude":-85.389703,
@@ -110,9 +110,10 @@
         "hasc:id":"NI.MT.MS",
         "wd:id":"Q2215416"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415167,
-    "wof:geomhash":"7dad52b6609e4b531f807cb4bf070e31",
+    "wof:geomhash":"7bfd15864be6ba5bb5f917a15666f1a0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108693833,
-    "wof:lastmodified":1690848458,
+    "wof:lastmodified":1695886487,
     "wof:name":"Matiguas",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/110/869/383/5/1108693835.geojson
+++ b/data/110/869/383/5/1108693835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024465,
-    "geom:area_square_m":295232970.192675,
+    "geom:area_square_m":295232970.192654,
     "geom:bbox":"-85.9487714781,12.5173190525,-85.6416690362,12.6591289007",
     "geom:latitude":12.595146,
     "geom:longitude":-85.792383,
@@ -93,9 +93,10 @@
         "hasc:id":"NI.BO.SJ",
         "wd:id":"Q2215558"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415169,
-    "wof:geomhash":"670e7c570c56a9e93f568dc493ad7835",
+    "wof:geomhash":"4ab3f19198aea8636685cd31553e7266",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108693835,
-    "wof:lastmodified":1566657000,
+    "wof:lastmodified":1695886487,
     "wof:name":"San Jose De Los Remates",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/110/869/383/7/1108693837.geojson
+++ b/data/110/869/383/7/1108693837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01004,
-    "geom:area_square_m":121201026.523376,
+    "geom:area_square_m":121201026.523364,
     "geom:bbox":"-85.7658961522,12.443015539,-85.6609880891,12.5759593429",
     "geom:latitude":12.510026,
     "geom:longitude":-85.716662,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"NI.BO.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415171,
-    "wof:geomhash":"c5982526f617ed9d8e001371c04aa5bb",
+    "wof:geomhash":"b29e3a6a2acee513312725909b2275b8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108693837,
-    "wof:lastmodified":1566657000,
+    "wof:lastmodified":1695886487,
     "wof:name":"Santa Lucia",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/110/869/383/9/1108693839.geojson
+++ b/data/110/869/383/9/1108693839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047621,
-    "geom:area_square_m":575453961.619881,
+    "geom:area_square_m":575453668.742967,
     "geom:bbox":"-85.831341,12.058253,-85.594145,12.428881",
     "geom:latitude":12.241271,
     "geom:longitude":-85.712632,
@@ -184,9 +184,10 @@
     "wof:concordances":{
         "hasc:id":"NI.BO.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415173,
-    "wof:geomhash":"3ff9ebf9daf6ca11912021e65ec60896",
+    "wof:geomhash":"fda7419c00ce164067c497cf08bd2b21",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":1108693839,
-    "wof:lastmodified":1636503396,
+    "wof:lastmodified":1695886115,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/110/869/384/1/1108693841.geojson
+++ b/data/110/869/384/1/1108693841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086852,
-    "geom:area_square_m":1048182999.120968,
+    "geom:area_square_m":1048183454.101068,
     "geom:bbox":"-85.693833,12.379031,-85.234822,12.730451",
     "geom:latitude":12.574336,
     "geom:longitude":-85.493331,
@@ -139,9 +139,10 @@
     "wof:concordances":{
         "hasc:id":"NI.BO.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415175,
-    "wof:geomhash":"cb1e31603632995ef6206ac066ad37fc",
+    "wof:geomhash":"47bd78ba3cc0400ee8217369e65fcb00",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108693841,
-    "wof:lastmodified":1636503397,
+    "wof:lastmodified":1695886116,
     "wof:name":"Boaco",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/110/869/384/3/1108693843.geojson
+++ b/data/110/869/384/3/1108693843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054924,
-    "geom:area_square_m":663834399.380013,
+    "geom:area_square_m":663834399.379905,
     "geom:bbox":"-85.6816310702,12.0074425698,-85.3795524515,12.3559306077",
     "geom:latitude":12.189804,
     "geom:longitude":-85.558142,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CO.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415177,
-    "wof:geomhash":"7549477704db84610f0bcd654ec14e52",
+    "wof:geomhash":"cbc569d2eabda7d5eb5be08b6a85cf21",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693843,
-    "wof:lastmodified":1566657002,
+    "wof:lastmodified":1695886487,
     "wof:name":"Comalapa",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/384/7/1108693847.geojson
+++ b/data/110/869/384/7/1108693847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078214,
-    "geom:area_square_m":945615118.220365,
+    "geom:area_square_m":945615542.054144,
     "geom:bbox":"-85.553686,11.864739,-85.263769,12.352442",
     "geom:latitude":12.107012,
     "geom:longitude":-85.395009,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CO.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415184,
-    "wof:geomhash":"197dd10305bc40cb6e751548c5ca7b6b",
+    "wof:geomhash":"a937cf6861347bace144ab4928d9b186",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108693847,
-    "wof:lastmodified":1636503397,
+    "wof:lastmodified":1695886116,
     "wof:name":"Juigalpa",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/384/9/1108693849.geojson
+++ b/data/110/869/384/9/1108693849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066668,
-    "geom:area_square_m":805274907.100786,
+    "geom:area_square_m":805273977.975612,
     "geom:bbox":"-85.335915,12.131481,-84.86899,12.632064",
     "geom:latitude":12.352852,
     "geom:longitude":-85.141327,
@@ -139,9 +139,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CO.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415185,
-    "wof:geomhash":"5dabf38eada2dda43d65feda9545be51",
+    "wof:geomhash":"66333664947cc56e817e85f16d571790",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108693849,
-    "wof:lastmodified":1636503397,
+    "wof:lastmodified":1695886116,
     "wof:name":"La Libertad",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/385/1/1108693851.geojson
+++ b/data/110/869/385/1/1108693851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053355,
-    "geom:area_square_m":644456447.733191,
+    "geom:area_square_m":644456447.733086,
     "geom:bbox":"-85.111606247,12.2237575023,-84.7828685069,12.529531535",
     "geom:latitude":12.358562,
     "geom:longitude":-84.956026,
@@ -367,9 +367,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CO.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415186,
-    "wof:geomhash":"4262072d71f29ccd96fe1ae0e1141a61",
+    "wof:geomhash":"7626fd5dfa6e8ed2526449bcf380cff5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -379,7 +380,7 @@
         }
     ],
     "wof:id":1108693851,
-    "wof:lastmodified":1566657003,
+    "wof:lastmodified":1695886488,
     "wof:name":"Santo Domingo",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/385/3/1108693853.geojson
+++ b/data/110/869/385/3/1108693853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039467,
-    "geom:area_square_m":477088228.548599,
+    "geom:area_square_m":477088645.685593,
     "geom:bbox":"-85.273613,12.0049,-84.884271,12.280937",
     "geom:latitude":12.147273,
     "geom:longitude":-85.105959,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CO.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415188,
-    "wof:geomhash":"1e585073f276a312c9846670c9bdeb8a",
+    "wof:geomhash":"b65e678b140fd109111fcbdb2c92d262",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108693853,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886102,
     "wof:name":"San Pedro De Lovago",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/385/5/1108693855.geojson
+++ b/data/110/869/385/5/1108693855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04146,
-    "geom:area_square_m":501242337.562117,
+    "geom:area_square_m":501243499.203218,
     "geom:bbox":"-85.164984,11.948088,-84.778318,12.295674",
     "geom:latitude":12.118027,
     "geom:longitude":-84.987834,
@@ -129,9 +129,10 @@
         "hasc:id":"NI.CO.ST",
         "wd:id":"Q542822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415189,
-    "wof:geomhash":"3953add54a605d8ec1a437e1b5982c2c",
+    "wof:geomhash":"8a4db344aba21d648f8f14d531887813",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693855,
-    "wof:lastmodified":1690848460,
+    "wof:lastmodified":1695886116,
     "wof:name":"Santo Tomas",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/385/7/1108693857.geojson
+++ b/data/110/869/385/7/1108693857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083512,
-    "geom:area_square_m":1010048999.75914,
+    "geom:area_square_m":1010048999.75885,
     "geom:bbox":"-85.0432608627,11.828384111,-84.5239918055,12.1979491894",
     "geom:latitude":12.003465,
     "geom:longitude":-84.810919,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CO.VS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415191,
-    "wof:geomhash":"d3f2bdb8b579ad4daaea273365ab8bb4",
+    "wof:geomhash":"f4009662107d01350e696eb3f192cb04",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108693857,
-    "wof:lastmodified":1566657003,
+    "wof:lastmodified":1695886488,
     "wof:name":"Villa Sandino",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/385/9/1108693859.geojson
+++ b/data/110/869/385/9/1108693859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116116,
-    "geom:area_square_m":1405132787.15754,
+    "geom:area_square_m":1405132787.157047,
     "geom:bbox":"-85.4211492376,11.6371206958,-84.8127376968,12.029635478",
     "geom:latitude":11.861253,
     "geom:longitude":-85.121734,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"NI.CO.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415192,
-    "wof:geomhash":"1c5ac3632620180ead0b06537841d196",
+    "wof:geomhash":"cb21d77fdf78093aee047c06d773476c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108693859,
-    "wof:lastmodified":1566657003,
+    "wof:lastmodified":1695886488,
     "wof:name":"Acoyapa",
     "wof:parent_id":85675525,
     "wof:placetype":"county",

--- a/data/110/869/386/1/1108693861.geojson
+++ b/data/110/869/386/1/1108693861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055209,
-    "geom:area_square_m":668626131.190682,
+    "geom:area_square_m":668626131.190638,
     "geom:bbox":"-85.1134410055,11.4794748282,-84.8048744735,11.7960446836",
     "geom:latitude":11.642159,
     "geom:longitude":-84.942792,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"NI.SJ.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415194,
-    "wof:geomhash":"bbc4454000846e7cc4fd823f2ca54e84",
+    "wof:geomhash":"d13bafdcce8ce9e72c7e45572e613f8b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693861,
-    "wof:lastmodified":1566657014,
+    "wof:lastmodified":1695886491,
     "wof:name":"Morrito",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/110/869/386/5/1108693865.geojson
+++ b/data/110/869/386/5/1108693865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087467,
-    "geom:area_square_m":1059019626.720284,
+    "geom:area_square_m":1059019382.51741,
     "geom:bbox":"-84.885135,11.542106,-84.521586,11.88244",
     "geom:latitude":11.714169,
     "geom:longitude":-84.696165,
@@ -106,9 +106,10 @@
         "hasc:id":"NI.SJ.EA",
         "wd:id":"Q2621532"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415195,
-    "wof:geomhash":"63568a16902b0b95e3fa00ea8aabdcb3",
+    "wof:geomhash":"af1178830d69d83e4f705d35e6c9ca3b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108693865,
-    "wof:lastmodified":1690848468,
+    "wof:lastmodified":1695886491,
     "wof:name":"El Almendro",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/110/869/386/7/1108693867.geojson
+++ b/data/110/869/386/7/1108693867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137908,
-    "geom:area_square_m":1673391673.760699,
+    "geom:area_square_m":1673391343.239147,
     "geom:bbox":"-84.530265,10.797047,-84.08609,11.404462",
     "geom:latitude":11.093576,
     "geom:longitude":-84.312861,
@@ -157,9 +157,10 @@
     "wof:concordances":{
         "hasc:id":"NI.SJ.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415198,
-    "wof:geomhash":"2935ba802a412fd97668e8bf0168f4ab",
+    "wof:geomhash":"e3006bfc1cff2c319fc8f5a398864473",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108693867,
-    "wof:lastmodified":1636503398,
+    "wof:lastmodified":1695886116,
     "wof:name":"San Carlos",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/110/869/386/9/1108693869.geojson
+++ b/data/110/869/386/9/1108693869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.275213,
-    "geom:area_square_m":3314871461.273914,
+    "geom:area_square_m":3314871461.274271,
     "geom:bbox":"-84.8043004779,12.75237646,-83.957004619,13.2901391332",
     "geom:latitude":13.072151,
     "geom:longitude":-84.392252,
@@ -78,9 +78,10 @@
         "hasc:id":"NI.AS.LC",
         "wd:id":"Q963732"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415201,
-    "wof:geomhash":"28af24c1f927b5147ca2efbc1e0e3354",
+    "wof:geomhash":"d8f0dacd710d4f0513770499e1c1a98c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108693869,
-    "wof:lastmodified":1566657013,
+    "wof:lastmodified":1695886491,
     "wof:name":"La Cruz De Rio Grande",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/110/869/387/1/1108693871.geojson
+++ b/data/110/869/387/1/1108693871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.201755,
-    "geom:area_square_m":2431640728.668514,
+    "geom:area_square_m":2431641066.840836,
     "geom:bbox":"-85.210747,12.658834,-84.621651,13.180041",
     "geom:latitude":12.913499,
     "geom:longitude":-84.918775,
@@ -88,9 +88,10 @@
         "hasc:id":"NI.MT.RB",
         "wd:id":"Q691374"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415202,
-    "wof:geomhash":"fb8b4d9c40a599d20b343d2067d2dbad",
+    "wof:geomhash":"4aaa6d413f49c7441e1fa9d4539a5e87",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108693871,
-    "wof:lastmodified":1690848465,
+    "wof:lastmodified":1695886490,
     "wof:name":"Rio Blanco",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/110/869/387/3/1108693873.geojson
+++ b/data/110/869/387/3/1108693873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091451,
-    "geom:area_square_m":1104788194.243106,
+    "geom:area_square_m":1104787929.409743,
     "geom:bbox":"-84.168634,12.111717,-83.664919,12.552986",
     "geom:latitude":12.31487,
     "geom:longitude":-83.922509,
@@ -116,9 +116,10 @@
         "hasc:id":"NI.AS.KH",
         "wd:id":"Q1647889"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415205,
-    "wof:geomhash":"29b80208f672322ed3f60b78633d6c8d",
+    "wof:geomhash":"c332e27f4e32e81ceaa96abe10e489f4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108693873,
-    "wof:lastmodified":1690848466,
+    "wof:lastmodified":1695886490,
     "wof:name":"Kukra Hill",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/110/869/387/5/1108693875.geojson
+++ b/data/110/869/387/5/1108693875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.118595,
-    "geom:area_square_m":1433703126.010404,
+    "geom:area_square_m":1433703126.010407,
     "geom:bbox":"-84.806550382,11.921261122,-84.3430798107,12.3627852946",
     "geom:latitude":12.130427,
     "geom:longitude":-84.585749,
@@ -90,9 +90,10 @@
         "hasc:id":"NI.AS.MB",
         "wd:id":"Q2215047"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415209,
-    "wof:geomhash":"7c1d632aa4e47b8be32513a640de85ec",
+    "wof:geomhash":"c91e223ca287ca8f6586098440d65703",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108693875,
-    "wof:lastmodified":1566657010,
+    "wof:lastmodified":1695886490,
     "wof:name":"Muelle De Los Bueyes",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/110/869/387/7/1108693877.geojson
+++ b/data/110/869/387/7/1108693877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263417,
-    "geom:area_square_m":3177244659.633372,
+    "geom:area_square_m":3177244659.63343,
     "geom:bbox":"-84.6576934434,12.445589188,-83.8215562358,12.9644578951",
     "geom:latitude":12.721181,
     "geom:longitude":-84.256,
@@ -78,9 +78,10 @@
         "hasc:id":"NI.AS.LC",
         "wd:id":"Q963732"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415210,
-    "wof:geomhash":"56cbb7c5515c832b4a9f1e279d2442b0",
+    "wof:geomhash":"0ae2635c3582b5a89f69ef6992084c96",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108693877,
-    "wof:lastmodified":1566657010,
+    "wof:lastmodified":1695886490,
     "wof:name":"La Cruz De Rio Grande",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/110/869/387/9/1108693879.geojson
+++ b/data/110/869/387/9/1108693879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143741,
-    "geom:area_square_m":1731659182.140157,
+    "geom:area_square_m":1731658706.159009,
     "geom:bbox":"-84.054958,12.784014,-83.507416,13.273367",
     "geom:latitude":13.024408,
     "geom:longitude":-83.788194,
@@ -84,9 +84,10 @@
         "hasc:id":"NI.AS.LP",
         "wd:id":"Q2215086"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1474415212,
-    "wof:geomhash":"0963d51236bd5e2f7d40923581f68426",
+    "wof:geomhash":"2f4e9e18aabcab754c987218526011a5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108693879,
-    "wof:lastmodified":1690848465,
+    "wof:lastmodified":1695886490,
     "wof:name":"Isla",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/168/431/421168431.geojson
+++ b/data/421/168/431/421168431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060272,
-    "geom:area_square_m":726522335.796262,
+    "geom:area_square_m":726523190.26373,
     "geom:bbox":"-86.687536,12.718544,-86.420208,13.114327",
     "geom:latitude":12.878691,
     "geom:longitude":-86.54238,
@@ -119,12 +119,13 @@
         "qs_pg:id":1113908,
         "wd:id":"Q1155040"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008764,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f2c6391172251d3ed9dbe66bf54ecdf",
+    "wof:geomhash":"85e3ada3451c9a3dd0a5c208d20fc647",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421168431,
-    "wof:lastmodified":1690848470,
+    "wof:lastmodified":1695886032,
     "wof:name":"El Sauce",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/170/019/421170019.geojson
+++ b/data/421/170/019/421170019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012067,
-    "geom:area_square_m":145945432.28026,
+    "geom:area_square_m":145945538.237329,
     "geom:bbox":"-86.112429,11.916114,-85.98766,12.14229",
     "geom:latitude":12.012889,
     "geom:longitude":-86.065745,
@@ -181,12 +181,13 @@
         "hasc:id":"NI.MS.MY",
         "qs_pg:id":772979
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008834,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5b0656a9e2d0971711de99f46c03af24",
+    "wof:geomhash":"234ba465ed9efb917a0815c9104bfac1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":421170019,
-    "wof:lastmodified":1636503411,
+    "wof:lastmodified":1695886117,
     "wof:name":"Masaya",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/170/023/421170023.geojson
+++ b/data/421/170/023/421170023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050022,
-    "geom:area_square_m":600371845.277947,
+    "geom:area_square_m":600371373.810027,
     "geom:bbox":"-86.273458,13.783641,-85.911893,14.06954",
     "geom:latitude":13.917086,
     "geom:longitude":-86.094426,
@@ -116,12 +116,13 @@
         "hasc:id":"NI.NS.JA",
         "qs_pg:id":772980
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008834,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59a625391cd679cd9883de609dcc0c61",
+    "wof:geomhash":"1a4b01dfb0a47ac75578a49ee89a8ca3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421170023,
-    "wof:lastmodified":1636503410,
+    "wof:lastmodified":1695886117,
     "wof:name":"Jalapa",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/421/170/061/421170061.geojson
+++ b/data/421/170/061/421170061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033819,
-    "geom:area_square_m":406896520.214827,
+    "geom:area_square_m":406897207.558359,
     "geom:bbox":"-86.486884,13.244239,-86.206875,13.432635",
     "geom:latitude":13.340361,
     "geom:longitude":-86.349915,
@@ -140,12 +140,13 @@
         "qs_pg:id":1264320,
         "wd:id":"Q1012589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008835,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab782e334d526f53b2eaaf7c3eddbb23",
+    "wof:geomhash":"0d10d5dcd30f798681971fbd18001c9a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421170061,
-    "wof:lastmodified":1690848494,
+    "wof:lastmodified":1695886034,
     "wof:name":"Condega",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/421/170/189/421170189.geojson
+++ b/data/421/170/189/421170189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105802,
-    "geom:area_square_m":1275719058.648084,
+    "geom:area_square_m":1275719766.6737,
     "geom:bbox":"-87.685091,12.546393,-87.109272,13.077158",
     "geom:latitude":12.805145,
     "geom:longitude":-87.405187,
@@ -143,12 +143,13 @@
         "qs_pg:id":224873,
         "wd:id":"Q516482"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008842,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f11130495ea182f1a7263823e913f61",
+    "wof:geomhash":"e35a4507f586b9cad242dbe1248d83c2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421170189,
-    "wof:lastmodified":1690848494,
+    "wof:lastmodified":1695886033,
     "wof:name":"El Viejo",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/170/971/421170971.geojson
+++ b/data/421/170/971/421170971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006668,
-    "geom:area_square_m":80120328.260084,
+    "geom:area_square_m":80120344.803297,
     "geom:bbox":"-86.546761,13.582879,-86.447494,13.693428",
     "geom:latitude":13.639488,
     "geom:longitude":-86.490039,
@@ -151,12 +151,13 @@
         "hasc:id":"NI.NS.OC",
         "qs_pg:id":1203947
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008876,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0409ce818e73b80c60d408e5076237f2",
+    "wof:geomhash":"cb2cd6fc948cdb854515e61446bef451",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":421170971,
-    "wof:lastmodified":1636503410,
+    "wof:lastmodified":1695886117,
     "wof:name":"Ocotal",
     "wof:parent_id":85675517,
     "wof:placetype":"county",

--- a/data/421/171/365/421171365.geojson
+++ b/data/421/171/365/421171365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056209,
-    "geom:area_square_m":677990938.175831,
+    "geom:area_square_m":677990409.703848,
     "geom:bbox":"-87.204215,12.529003,-86.815377,12.864997",
     "geom:latitude":12.715484,
     "geom:longitude":-87.019624,
@@ -184,12 +184,13 @@
         "hasc:id":"NI.CI.CN",
         "qs_pg:id":1264307
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008891,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b949127ead1a51b6fb28597d63ef0bff",
+    "wof:geomhash":"fe191c769831332c452a26d8b4e6591b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":421171365,
-    "wof:lastmodified":1636503412,
+    "wof:lastmodified":1695886117,
     "wof:name":"Chinandega",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/171/539/421171539.geojson
+++ b/data/421/171/539/421171539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053986,
-    "geom:area_square_m":650664734.822887,
+    "geom:area_square_m":650663998.629124,
     "geom:bbox":"-86.059943,12.757896,-85.682548,13.099021",
     "geom:latitude":12.914263,
     "geom:longitude":-85.90013,
@@ -100,12 +100,13 @@
         "hasc:id":"NI.MT.MP",
         "qs_pg:id":1264328
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008897,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0b1d4f14ca48fea9e9a69a015311a82",
+    "wof:geomhash":"83482264852cee18cc784d462e455e32",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":421171539,
-    "wof:lastmodified":1636503412,
+    "wof:lastmodified":1695886118,
     "wof:name":"Matagalpa",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/171/787/421171787.geojson
+++ b/data/421/171/787/421171787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050867,
-    "geom:area_square_m":614252065.774559,
+    "geom:area_square_m":614252060.374132,
     "geom:bbox":"-85.982277,12.273383,-85.663129,12.565176",
     "geom:latitude":12.425683,
     "geom:longitude":-85.837413,
@@ -137,12 +137,13 @@
         "qs_pg:id":1264305,
         "wd:id":"Q2216040"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1777db11efb162d098ae39b1382ec24f",
+    "wof:geomhash":"29ba706286e80b69b4c5543c7ea7f82a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421171787,
-    "wof:lastmodified":1690848503,
+    "wof:lastmodified":1695886034,
     "wof:name":"Teustepe",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/421/171/789/421171789.geojson
+++ b/data/421/171/789/421171789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004195,
-    "geom:area_square_m":50771327.029113,
+    "geom:area_square_m":50771258.950106,
     "geom:bbox":"-86.066961,11.795421,-85.996273,11.897152",
     "geom:latitude":11.851149,
     "geom:longitude":-86.035578,
@@ -140,12 +140,13 @@
         "qs_pg:id":1264321,
         "wd:id":"Q2215569"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cb2233f992235a77651d3b9b3534574e",
+    "wof:geomhash":"42face12abecc5a1e52377c3cdcc8272",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421171789,
-    "wof:lastmodified":1690848503,
+    "wof:lastmodified":1695886034,
     "wof:name":"Diriomo",
     "wof:parent_id":85675477,
     "wof:placetype":"county",

--- a/data/421/171/791/421171791.geojson
+++ b/data/421/171/791/421171791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030284,
-    "geom:area_square_m":366670782.732009,
+    "geom:area_square_m":366670551.750703,
     "geom:bbox":"-86.129896,11.601649,-85.894055,11.825526",
     "geom:latitude":11.708095,
     "geom:longitude":-86.024722,
@@ -140,12 +140,13 @@
         "qs_pg:id":1264322,
         "wd:id":"Q1964554"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9ccbae5b988c27214f96f18894922d31",
+    "wof:geomhash":"c2ddeb16a28a2fe0f3b327b81518604f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421171791,
-    "wof:lastmodified":1690848502,
+    "wof:lastmodified":1695886034,
     "wof:name":"Nandaime",
     "wof:parent_id":85675477,
     "wof:placetype":"county",

--- a/data/421/171/799/421171799.geojson
+++ b/data/421/171/799/421171799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03794,
-    "geom:area_square_m":456111976.071951,
+    "geom:area_square_m":456111812.300672,
     "geom:bbox":"-86.760984,13.423459,-86.508289,13.664493",
     "geom:latitude":13.531238,
     "geom:longitude":-86.648404,
@@ -100,12 +100,13 @@
         "hasc:id":"NI.MD.SO",
         "qs_pg:id":1264327
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9bcef7828ef244aa309c2802d3ca5e58",
+    "wof:geomhash":"ad0112ded6516abd7a837536b280078e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":421171799,
-    "wof:lastmodified":1636503412,
+    "wof:lastmodified":1695886118,
     "wof:name":"Somoto",
     "wof:parent_id":85675511,
     "wof:placetype":"county",

--- a/data/421/171/805/421171805.geojson
+++ b/data/421/171/805/421171805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061943,
-    "geom:area_square_m":747240440.335652,
+    "geom:area_square_m":747240797.838275,
     "geom:bbox":"-86.286441,12.53623,-85.889078,12.832306",
     "geom:latitude":12.683868,
     "geom:longitude":-86.103328,
@@ -165,12 +165,13 @@
         "qs_pg:id":1264347,
         "wd:id":"Q1015865"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63ca08fa5818baf7ea2f307aad88d52a",
+    "wof:geomhash":"6eb830bdc1108a4c2df420e755c712f5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":421171805,
-    "wof:lastmodified":1690848502,
+    "wof:lastmodified":1695886034,
     "wof:name":"Ciudad Dario",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/171/813/421171813.geojson
+++ b/data/421/171/813/421171813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.381705,
-    "geom:area_square_m":4611704104.722748,
+    "geom:area_square_m":4611704515.541347,
     "geom:bbox":"-84.977699,11.712041,-83.929207,12.730331",
     "geom:latitude":12.288786,
     "geom:longitude":-84.383492,
@@ -134,12 +134,13 @@
         "qs_pg:id":1264353,
         "wd:id":"Q1324576"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2fe9d8df9bda1a956f8ca7fe9326acde",
+    "wof:geomhash":"690b6d031c02c24106dd8a614105af32",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421171813,
-    "wof:lastmodified":1690848502,
+    "wof:lastmodified":1695886034,
     "wof:name":"El Rama",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/172/641/421172641.geojson
+++ b/data/421/172/641/421172641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.734912,
-    "geom:area_square_m":8900409959.569912,
+    "geom:area_square_m":8900410011.441856,
     "geom:bbox":"-86.611555,11.028472,-84.740603,13.236119",
     "geom:latitude":11.635343,
     "geom:longitude":-85.514942,
@@ -167,12 +167,13 @@
         "hasc:id":"NI.JI.JI",
         "qs_pg:id":1315010
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008949,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48265e444e56c0a04dae579e936f142f",
+    "wof:geomhash":"34436408d06cdb91edacb066de06f4ab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":421172641,
-    "wof:lastmodified":1636503408,
+    "wof:lastmodified":1695886116,
     "wof:name":"Jinotega",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/172/925/421172925.geojson
+++ b/data/421/172/925/421172925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007841,
-    "geom:area_square_m":94639221.367056,
+    "geom:area_square_m":94638973.686696,
     "geom:bbox":"-87.005488,12.470469,-86.87613,12.642527",
     "geom:latitude":12.542431,
     "geom:longitude":-86.918963,
@@ -131,12 +131,13 @@
         "qs_pg:id":485305,
         "wd:id":"Q739841"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459008959,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f41dd91a68b88d84b14b24d514d34c2",
+    "wof:geomhash":"463389faf79fe7ccc8a38b89cb215629",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421172925,
-    "wof:lastmodified":1690848484,
+    "wof:lastmodified":1695886032,
     "wof:name":"Quezalguaque",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/175/425/421175425.geojson
+++ b/data/421/175/425/421175425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050975,
-    "geom:area_square_m":616131172.181889,
+    "geom:area_square_m":616131509.812804,
     "geom:bbox":"-86.768285,11.98377,-86.476259,12.317602",
     "geom:latitude":12.177994,
     "geom:longitude":-86.631808,
@@ -140,12 +140,13 @@
         "qs_pg:id":369077,
         "wd:id":"Q2604568"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009067,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e1a6c16efec1861ac86d60073a02b06",
+    "wof:geomhash":"f41957a2c72599d6a9763d3a67947695",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421175425,
-    "wof:lastmodified":1690848487,
+    "wof:lastmodified":1695886034,
     "wof:name":"Nagarote",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/175/427/421175427.geojson
+++ b/data/421/175/427/421175427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079093,
-    "geom:area_square_m":955416003.210187,
+    "geom:area_square_m":955416789.016411,
     "geom:bbox":"-86.138807,12.14114,-85.804186,12.585043",
     "geom:latitude":12.335751,
     "geom:longitude":-86.010984,
@@ -161,12 +161,13 @@
         "qs_pg:id":369078,
         "wd:id":"Q1365146"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009067,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4d1d67d38640f793bf6d209f7b762278",
+    "wof:geomhash":"9ad0840794093d5f181fc5b91a41f1ff",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":421175427,
-    "wof:lastmodified":1690848487,
+    "wof:lastmodified":1695886034,
     "wof:name":"Tipitapa",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/175/429/421175429.geojson
+++ b/data/421/175/429/421175429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13333,
-    "geom:area_square_m":1618873178.216781,
+    "geom:area_square_m":1618873039.38713,
     "geom:bbox":"-84.155121,10.711032,-83.664415,11.134673",
     "geom:latitude":10.906598,
     "geom:longitude":-83.93062,
@@ -134,12 +134,13 @@
         "qs_pg:id":369091,
         "wd:id":"Q2063725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009067,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"07f4fb67c2e783a53455eca964af3586",
+    "wof:geomhash":"f1b22f93cc14783864dd7f16fd331efd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421175429,
-    "wof:lastmodified":1636503409,
+    "wof:lastmodified":1695886117,
     "wof:name":"Bluefields",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/421/176/721/421176721.geojson
+++ b/data/421/176/721/421176721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.186602,
-    "geom:area_square_m":2239391201.626526,
+    "geom:area_square_m":2239391831.858231,
     "geom:bbox":"-84.525364,13.63586,-84.048613,14.243279",
     "geom:latitude":13.942713,
     "geom:longitude":-84.284366,
@@ -116,12 +116,13 @@
         "hasc:id":"NI.AN.RO",
         "qs_pg:id":392795
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009117,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5201b18ef0bb1a8b6e08de4c7f86d37",
+    "wof:geomhash":"1806cacac461f4fde0046d0d18694971",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421176721,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886101,
     "wof:name":"Rosita",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/421/178/593/421178593.geojson
+++ b/data/421/178/593/421178593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003484,
-    "geom:area_square_m":42068988.4592,
+    "geom:area_square_m":42068730.820518,
     "geom:bbox":"-87.238274,12.397112,-87.06707,12.546803",
     "geom:latitude":12.473727,
     "geom:longitude":-87.140998,
@@ -164,12 +164,13 @@
         "qs_pg:id":467362,
         "wd:id":"Q1132939"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009187,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"106da3af5b07bf6b26bc461d67643a71",
+    "wof:geomhash":"10aaa99596d10bb9cfa3b86a83b92387",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421178593,
-    "wof:lastmodified":1690848499,
+    "wof:lastmodified":1695886035,
     "wof:name":"Corinto",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/179/217/421179217.geojson
+++ b/data/421/179/217/421179217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004906,
-    "geom:area_square_m":59339852.532784,
+    "geom:area_square_m":59340103.364029,
     "geom:bbox":"-86.287015,11.975466,-86.175878,12.056694",
     "geom:latitude":12.009934,
     "geom:longitude":-86.220703,
@@ -134,12 +134,13 @@
         "qs_pg:id":369089,
         "wd:id":"Q2216951"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009208,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"49923866acf29a7c728293781848496e",
+    "wof:geomhash":"284cbe4a895ae4a70d33a30cad630908",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421179217,
-    "wof:lastmodified":1690848497,
+    "wof:lastmodified":1695886035,
     "wof:name":"Ticuantepe",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/179/703/421179703.geojson
+++ b/data/421/179/703/421179703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029964,
-    "geom:area_square_m":361570491.270264,
+    "geom:area_square_m":361570660.389551,
     "geom:bbox":"-86.89063,12.477678,-86.713193,12.75322",
     "geom:latitude":12.608024,
     "geom:longitude":-86.811157,
@@ -131,12 +131,13 @@
         "qs_pg:id":485304,
         "wd:id":"Q1647817"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009230,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9bd4911de7d0944b383d56775627d5ff",
+    "wof:geomhash":"91abfea64dd3c6b5fca8256369282093",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421179703,
-    "wof:lastmodified":1690848498,
+    "wof:lastmodified":1695886035,
     "wof:name":"Telica",
     "wof:parent_id":85675489,
     "wof:placetype":"county",

--- a/data/421/180/305/421180305.geojson
+++ b/data/421/180/305/421180305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046864,
-    "geom:area_square_m":566682193.794881,
+    "geom:area_square_m":566682193.794771,
     "geom:bbox":"-86.449916,11.912528,-86.121437,12.186428",
     "geom:latitude":12.063527,
     "geom:longitude":-86.304173,
@@ -421,6 +421,7 @@
         "hasc:id":"NI.MN.MN",
         "qs_pg:id":425490
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         890451731
     ],
@@ -429,7 +430,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9edfc5ee9555aba4842c0cf54c0b21e5",
+    "wof:geomhash":"8a6a68389b31c0b8e4f2e929582fade9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -439,7 +440,7 @@
         }
     ],
     "wof:id":421180305,
-    "wof:lastmodified":1636503407,
+    "wof:lastmodified":1695886116,
     "wof:name":"Managua",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/183/419/421183419.geojson
+++ b/data/421/183/419/421183419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170095,
-    "geom:area_square_m":2052783644.426415,
+    "geom:area_square_m":2052783982.837556,
     "geom:bbox":"-84.005073,12.249635,-83.488206,12.84838",
     "geom:latitude":12.577468,
     "geom:longitude":-83.773109,
@@ -108,12 +108,13 @@
         "qs_pg:id":975246,
         "wd:id":"Q2215086"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009368,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac4670f41c6475509f9bb856bf5f1216",
+    "wof:geomhash":"d25455850507b6ef3d72dc42ea93d279",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421183419,
-    "wof:lastmodified":1690848496,
+    "wof:lastmodified":1695886035,
     "wof:name":"Isla",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/185/081/421185081.geojson
+++ b/data/421/185/081/421185081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005047,
-    "geom:area_square_m":60752745.931632,
+    "geom:area_square_m":60752670.439575,
     "geom:bbox":"-86.9061,13.159214,-86.815671,13.25275",
     "geom:latitude":13.214385,
     "geom:longitude":-86.856006,
@@ -136,12 +136,13 @@
         "qs_pg:id":1017819,
         "wd:id":"Q1647867"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009432,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec73aab9ebf146b5a05b2504ea05cd20",
+    "wof:geomhash":"9d9c87b8e471dea6a7367a9f958fc218",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421185081,
-    "wof:lastmodified":1690848504,
+    "wof:lastmodified":1695886035,
     "wof:name":"Cinco Pinos",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/186/279/421186279.geojson
+++ b/data/421/186/279/421186279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.379981,
-    "geom:area_square_m":4602922467.401078,
+    "geom:area_square_m":4602922693.909863,
     "geom:bbox":"-84.395821,10.946124,-83.646467,12.179323",
     "geom:latitude":11.575824,
     "geom:longitude":-83.963802,
@@ -178,12 +178,13 @@
         "hasc:id":"NI.AS.BL",
         "qs_pg:id":1063198
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009476,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"12b07739e4143f9f612416a5e7c6bd77",
+    "wof:geomhash":"8db92c7bde6f17cc0103fdd9f8d5a846",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":421186279,
-    "wof:lastmodified":1636503409,
+    "wof:lastmodified":1695886117,
     "wof:name":"Bluefields",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/189/523/421189523.geojson
+++ b/data/421/189/523/421189523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125149,
-    "geom:area_square_m":1510700786.340923,
+    "geom:area_square_m":1510700988.143201,
     "geom:bbox":"-85.599413,12.319824,-84.957312,12.802382",
     "geom:latitude":12.518242,
     "geom:longitude":-85.234668,
@@ -140,12 +140,13 @@
         "qs_pg:id":1113889,
         "wd:id":"Q2605022"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009627,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67392d889a43b261b8edee1f43946fc7",
+    "wof:geomhash":"ad1749c55a8812600283f9b725a0c917",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421189523,
-    "wof:lastmodified":1690848483,
+    "wof:lastmodified":1695886033,
     "wof:name":"Camoapa",
     "wof:parent_id":85675521,
     "wof:placetype":"county",

--- a/data/421/189/527/421189527.geojson
+++ b/data/421/189/527/421189527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017508,
-    "geom:area_square_m":211318076.278092,
+    "geom:area_square_m":211318345.427905,
     "geom:bbox":"-87.135224,12.469006,-86.947293,12.689503",
     "geom:latitude":12.555378,
     "geom:longitude":-87.036068,
@@ -143,12 +143,13 @@
         "qs_pg:id":1113891,
         "wd:id":"Q1072117"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009628,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a7eb364fb95d7f294ecce980e4d80af5",
+    "wof:geomhash":"5f475dbe0413dec3e8fd2a4b05eaee3b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421189527,
-    "wof:lastmodified":1690848483,
+    "wof:lastmodified":1695886033,
     "wof:name":"Chichigalpa",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/190/545/421190545.geojson
+++ b/data/421/190/545/421190545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040182,
-    "geom:area_square_m":486952823.54845,
+    "geom:area_square_m":486952823.548353,
     "geom:bbox":"-86.1714048151,11.2997377682,-85.8802927299,11.5831313032",
     "geom:latitude":11.457601,
     "geom:longitude":-86.021515,
@@ -113,12 +113,13 @@
         "hasc:id":"NI.RI.TO",
         "qs_pg:id":1119699
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009661,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4aa5d1d5ea8efeb3fc770ed84eb32b63",
+    "wof:geomhash":"f5e61ff155b56faa39a5477f784808e3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421190545,
-    "wof:lastmodified":1582361967,
+    "wof:lastmodified":1695886034,
     "wof:name":"Tola",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/191/489/421191489.geojson
+++ b/data/421/191/489/421191489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022091,
-    "geom:area_square_m":267482134.482115,
+    "geom:area_square_m":267481899.418149,
     "geom:bbox":"-86.36683,11.547286,-86.152162,11.895816",
     "geom:latitude":11.697174,
     "geom:longitude":-86.245274,
@@ -97,12 +97,13 @@
         "hasc:id":"NI.CA.JI",
         "qs_pg:id":1137366
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009694,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"26e442aba147f1774eff0aab87ad6cb5",
+    "wof:geomhash":"5597173769174e5b12f400ada3e8e604",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421191489,
-    "wof:lastmodified":1636503409,
+    "wof:lastmodified":1695886117,
     "wof:name":"Jinotepe",
     "wof:parent_id":85675471,
     "wof:placetype":"county",

--- a/data/421/192/911/421192911.geojson
+++ b/data/421/192/911/421192911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.213984,
-    "geom:area_square_m":2590983435.721749,
+    "geom:area_square_m":2590983689.115775,
     "geom:bbox":"-84.610732,11.378316,-84.013862,11.996935",
     "geom:latitude":11.694841,
     "geom:longitude":-84.344091,
@@ -137,12 +137,13 @@
         "qs_pg:id":1183019,
         "wd:id":"Q2554341"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009753,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a9484c1c4c6d2566363a13706bf7a418",
+    "wof:geomhash":"e74e6d2a1cd3e52d04b555eeb908fe6b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421192911,
-    "wof:lastmodified":1690848471,
+    "wof:lastmodified":1695886033,
     "wof:name":"Nueva Guinea",
     "wof:parent_id":85675467,
     "wof:placetype":"county",

--- a/data/421/193/389/421193389.geojson
+++ b/data/421/193/389/421193389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073457,
-    "geom:area_square_m":885128222.385039,
+    "geom:area_square_m":885127574.377918,
     "geom:bbox":"-87.385263,12.809679,-86.749405,13.182281",
     "geom:latitude":12.971452,
     "geom:longitude":-87.025355,
@@ -138,12 +138,13 @@
         "qs_pg:id":893652,
         "wd:id":"Q2604179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009769,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20d415e94a789566069bce2848e2ce3a",
+    "wof:geomhash":"0b152ce058ff12ab3bb3a964c3628406",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421193389,
-    "wof:lastmodified":1690848475,
+    "wof:lastmodified":1695886033,
     "wof:name":"Isla Mangles Altos",
     "wof:parent_id":85675503,
     "wof:placetype":"county",

--- a/data/421/193/737/421193737.geojson
+++ b/data/421/193/737/421193737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001165,
-    "geom:area_square_m":14098739.305408,
+    "geom:area_square_m":14098764.865867,
     "geom:bbox":"-86.132286,11.885938,-86.10496,11.945435",
     "geom:latitude":11.916025,
     "geom:longitude":-86.119428,
@@ -131,12 +131,13 @@
         "qs_pg:id":116369,
         "wd:id":"Q641207"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009781,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a9128cc3cdabdf9d10305424650e370e",
+    "wof:geomhash":"da464a52bee75f8a6d33e39181d08b80",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421193737,
-    "wof:lastmodified":1690848475,
+    "wof:lastmodified":1695886033,
     "wof:name":"Nandasmo",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/197/135/421197135.geojson
+++ b/data/421/197/135/421197135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051839,
-    "geom:area_square_m":627042181.203935,
+    "geom:area_square_m":627041932.117577,
     "geom:bbox":"-86.03764,11.696707,-85.785191,12.213491",
     "geom:latitude":11.978483,
     "geom:longitude":-85.922613,
@@ -388,12 +388,13 @@
         "hasc:id":"NI.GR.GR",
         "qs_pg:id":1315009
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009904,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b3d54a33d98eb294f1b00cd3d05ab2a9",
+    "wof:geomhash":"96f9516a569e451b696e60b98ce53897",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -403,7 +404,7 @@
         }
     ],
     "wof:id":421197135,
-    "wof:lastmodified":1636503409,
+    "wof:lastmodified":1695886117,
     "wof:name":"Granada",
     "wof:parent_id":85675477,
     "wof:placetype":"county",

--- a/data/421/197/835/421197835.geojson
+++ b/data/421/197/835/421197835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022963,
-    "geom:area_square_m":278393736.536333,
+    "geom:area_square_m":278394034.766363,
     "geom:bbox":"-85.923254,11.203544,-85.644603,11.478636",
     "geom:latitude":11.344584,
     "geom:longitude":-85.790126,
@@ -230,12 +230,13 @@
         "qs_pg:id":425503,
         "wd:id":"Q1757609"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459009926,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f2f6abe225cda7ff6ac086ce07c6d64d",
+    "wof:geomhash":"ef5683d91c5d3727af36667d41292299",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -245,7 +246,7 @@
         }
     ],
     "wof:id":421197835,
-    "wof:lastmodified":1690848489,
+    "wof:lastmodified":1695886117,
     "wof:name":"Rivas",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/200/101/421200101.geojson
+++ b/data/421/200/101/421200101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054487,
-    "geom:area_square_m":656361245.833157,
+    "geom:area_square_m":656361245.833166,
     "geom:bbox":"-85.4002103759,12.8106661846,-85.0726898012,13.1837983076",
     "geom:latitude":13.042081,
     "geom:longitude":-85.235576,
@@ -108,12 +108,13 @@
         "hasc:id":"NI.MT.RB",
         "qs_pg:id":772974
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010011,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d92aa4c4e03aa0275841cd7446963e1b",
+    "wof:geomhash":"5b7115bb3a901343f5f719d3410d8cbf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421200101,
-    "wof:lastmodified":1582361967,
+    "wof:lastmodified":1695886034,
     "wof:name":"Rio Blanco",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/200/103/421200103.geojson
+++ b/data/421/200/103/421200103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033143,
-    "geom:area_square_m":399713988.856792,
+    "geom:area_square_m":399714842.273268,
     "geom:bbox":"-85.721227,12.65916,-85.421822,12.847541",
     "geom:latitude":12.753221,
     "geom:longitude":-85.594088,
@@ -131,12 +131,13 @@
         "qs_pg:id":772975,
         "wd:id":"Q2215631"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010011,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b60b5663eff0b67d7f10ea5b2ab410f",
+    "wof:geomhash":"0899b6d7004ebe87ac9ea853cf9488ab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421200103,
-    "wof:lastmodified":1690848491,
+    "wof:lastmodified":1695886034,
     "wof:name":"Muy Muy",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/200/105/421200105.geojson
+++ b/data/421/200/105/421200105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019708,
-    "geom:area_square_m":237719731.957511,
+    "geom:area_square_m":237719455.586844,
     "geom:bbox":"-86.051819,12.62287,-85.859646,12.828145",
     "geom:latitude":12.710211,
     "geom:longitude":-85.960971,
@@ -134,12 +134,13 @@
         "qs_pg:id":772976,
         "wd:id":"Q664620"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010011,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"323d4f89af590965becd13447d04be2e",
+    "wof:geomhash":"d30dacf65dbd5f70fae6d280e1487f92",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421200105,
-    "wof:lastmodified":1690848491,
+    "wof:lastmodified":1695886034,
     "wof:name":"Terrabona",
     "wof:parent_id":85675513,
     "wof:placetype":"county",

--- a/data/421/200/107/421200107.geojson
+++ b/data/421/200/107/421200107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242437,
-    "geom:area_square_m":2909868107.101082,
+    "geom:area_square_m":2909867279.424533,
     "geom:bbox":"-85.928799,13.466333,-85.072849,14.546048",
     "geom:latitude":13.908257,
     "geom:longitude":-85.54717,
@@ -119,12 +119,13 @@
         "qs_pg:id":773176,
         "wd:id":"Q593730"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010011,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7cf70357db7c895f9742896a90cd6dde",
+    "wof:geomhash":"ac48a57f8307ca8346f8c8abd33d9fec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421200107,
-    "wof:lastmodified":1690848492,
+    "wof:lastmodified":1695886034,
     "wof:name":"Wiwili",
     "wof:parent_id":85675481,
     "wof:placetype":"county",

--- a/data/421/201/657/421201657.geojson
+++ b/data/421/201/657/421201657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.496644,
-    "geom:area_square_m":5953261690.824928,
+    "geom:area_square_m":5953259267.225655,
     "geom:bbox":"-84.111262,13.657119,-83.205142,14.684051",
     "geom:latitude":14.202086,
     "geom:longitude":-83.609967,
@@ -163,12 +163,13 @@
         "hasc:id":"NI.AN.PC",
         "qs_pg:id":1264352
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010080,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"95eed751e0b3c8d47e338b009e74e4fa",
+    "wof:geomhash":"10b5003861a645b277e2badc195e61b0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421201657,
-    "wof:lastmodified":1636503410,
+    "wof:lastmodified":1695886117,
     "wof:name":"Puerto Cabezas",
     "wof:parent_id":85675485,
     "wof:placetype":"county",

--- a/data/421/202/283/421202283.geojson
+++ b/data/421/202/283/421202283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023157,
-    "geom:area_square_m":279869165.247254,
+    "geom:area_square_m":279868680.822907,
     "geom:bbox":"-86.524327,12.104231,-86.295713,12.290934",
     "geom:latitude":12.208699,
     "geom:longitude":-86.409969,
@@ -140,12 +140,13 @@
         "qs_pg:id":220314,
         "wd:id":"Q2605008"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010111,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"69e3fb094b41bbb5c940c922015ef209",
+    "wof:geomhash":"0e0fae22ab797fbbc53efd1771969858",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421202283,
-    "wof:lastmodified":1690848479,
+    "wof:lastmodified":1695886033,
     "wof:name":"Mateare",
     "wof:parent_id":85675495,
     "wof:placetype":"county",

--- a/data/421/202/287/421202287.geojson
+++ b/data/421/202/287/421202287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005123,
-    "geom:area_square_m":62063547.474136,
+    "geom:area_square_m":62063260.028561,
     "geom:bbox":"-85.909148,11.467573,-85.789325,11.695326",
     "geom:latitude":11.567495,
     "geom:longitude":-85.844379,
@@ -125,12 +125,13 @@
         "qs_pg:id":220316,
         "wd:id":"Q1648230"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ce818a481464d8ddbc324cac8b42477",
+    "wof:geomhash":"2cd2b5a7e63236347374d3c0ef65b619",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421202287,
-    "wof:lastmodified":1690848477,
+    "wof:lastmodified":1695886033,
     "wof:name":"Buenos Aires",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/289/421202289.geojson
+++ b/data/421/202/289/421202289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005273,
-    "geom:area_square_m":63888616.655017,
+    "geom:area_square_m":63888703.959007,
     "geom:bbox":"-85.71606,11.467576,-85.64662,11.580857",
     "geom:latitude":11.518938,
     "geom:longitude":-85.676098,
@@ -134,12 +134,13 @@
         "qs_pg:id":220317,
         "wd:id":"Q2215641"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0e84a8e0e2faa38633fd4aa6e1c53ba",
+    "wof:geomhash":"0ad196c2898412341fce52b8ae98db17",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421202289,
-    "wof:lastmodified":1690848478,
+    "wof:lastmodified":1695886033,
     "wof:name":"Moyogalpa",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/291/421202291.geojson
+++ b/data/421/202/291/421202291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018258,
-    "geom:area_square_m":221236377.590257,
+    "geom:area_square_m":221236155.758017,
     "geom:bbox":"-85.655567,11.392508,-85.455661,11.589234",
     "geom:latitude":11.486661,
     "geom:longitude":-85.562014,
@@ -134,12 +134,13 @@
         "qs_pg:id":220318,
         "wd:id":"Q1647907"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1a7ff48752832a7d6c437197fdd25447",
+    "wof:geomhash":"f4b436310973cab8f4a0aa3239bec4ac",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421202291,
-    "wof:lastmodified":1690848479,
+    "wof:lastmodified":1695886033,
     "wof:name":"Altagracia",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/293/421202293.geojson
+++ b/data/421/202/293/421202293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002552,
-    "geom:area_square_m":30930570.682963,
+    "geom:area_square_m":30930447.129462,
     "geom:bbox":"-85.819782,11.378032,-85.764217,11.468446",
     "geom:latitude":11.423049,
     "geom:longitude":-85.793533,
@@ -143,12 +143,13 @@
         "qs_pg:id":220319,
         "wd:id":"Q956573"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46e879077e2d5a6db4377c9fed9441b4",
+    "wof:geomhash":"764d1fd84b65c61622588ca18e790e17",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421202293,
-    "wof:lastmodified":1690848478,
+    "wof:lastmodified":1695886033,
     "wof:name":"San Jorge",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/202/297/421202297.geojson
+++ b/data/421/202/297/421202297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034773,
-    "geom:area_square_m":421764233.039887,
+    "geom:area_square_m":421764233.039909,
     "geom:bbox":"-85.9308340199,11.073586727,-85.6358989775,11.3474364143",
     "geom:latitude":11.216943,
     "geom:longitude":-85.782553,
@@ -124,12 +124,13 @@
         "qs_pg:id":220320,
         "wd:id":"Q240247"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7743a194afa80791d4887cf16add23a4",
+    "wof:geomhash":"692e8c59799462b24853023bf4e5fd19",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421202297,
-    "wof:lastmodified":1582361966,
+    "wof:lastmodified":1695886033,
     "wof:name":"Tola",
     "wof:parent_id":85675461,
     "wof:placetype":"county",

--- a/data/421/203/775/421203775.geojson
+++ b/data/421/203/775/421203775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001123,
-    "geom:area_square_m":13580824.118626,
+    "geom:area_square_m":13580855.738849,
     "geom:bbox":"-86.092531,11.906634,-86.036018,11.947247",
     "geom:latitude":11.925293,
     "geom:longitude":-86.06456,
@@ -146,12 +146,13 @@
         "qs_pg:id":116360,
         "wd:id":"Q1647897"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010163,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e5be9c81b0011faabc6156bf11b72ce",
+    "wof:geomhash":"a0891277f83e2c8d367919c22a2acffb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421203775,
-    "wof:lastmodified":1690848477,
+    "wof:lastmodified":1695886033,
     "wof:name":"Catarina",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/203/777/421203777.geojson
+++ b/data/421/203/777/421203777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004994,
-    "geom:area_square_m":60429522.376123,
+    "geom:area_square_m":60429360.945768,
     "geom:bbox":"-86.177917,11.835559,-86.114817,11.970607",
     "geom:latitude":11.903591,
     "geom:longitude":-86.143072,
@@ -143,12 +143,13 @@
         "qs_pg:id":116364,
         "wd:id":"Q2720586"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010163,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1490eb6c10d7f66148a134bd739d4cb0",
+    "wof:geomhash":"330e99da8f51945136a7a990b51b7726",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421203777,
-    "wof:lastmodified":1690848477,
+    "wof:lastmodified":1695886033,
     "wof:name":"Masatepe",
     "wof:parent_id":85675499,
     "wof:placetype":"county",

--- a/data/421/204/571/421204571.geojson
+++ b/data/421/204/571/421204571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124173,
-    "geom:area_square_m":1506414649.068188,
+    "geom:area_square_m":1506414523.934971,
     "geom:bbox":"-85.178506,10.939769,-84.443997,11.416617",
     "geom:latitude":11.156458,
     "geom:longitude":-84.732449,
@@ -185,12 +185,13 @@
         "hasc:id":"NI.SJ.SC",
         "qs_pg:id":241938
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010191,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c29e38626a3bb451094ab60985b2566f",
+    "wof:geomhash":"3ac098f7f5e6f0bf0f57eb4f67847a48",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421204571,
-    "wof:lastmodified":1636503407,
+    "wof:lastmodified":1695886116,
     "wof:name":"San Carlos",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/421/205/285/421205285.geojson
+++ b/data/421/205/285/421205285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018316,
-    "geom:area_square_m":220363024.735247,
+    "geom:area_square_m":220362815.551261,
     "geom:bbox":"-86.617263,13.267907,-86.441181,13.431425",
     "geom:latitude":13.347232,
     "geom:longitude":-86.527065,
@@ -93,12 +93,13 @@
         "hasc:id":"NI.ES.PN",
         "qs_pg:id":260430
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010217,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec97543994ca59fc2e78356a04330edf",
+    "wof:geomhash":"de8f99841126ea805be5e1a3188d91e4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421205285,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886101,
     "wof:name":"Plueblo Nuevo",
     "wof:parent_id":85675505,
     "wof:placetype":"county",

--- a/data/421/205/287/421205287.geojson
+++ b/data/421/205/287/421205287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093586,
-    "geom:area_square_m":1134210007.282768,
+    "geom:area_square_m":1134209807.938424,
     "geom:bbox":"-84.968855,11.281435,-84.455239,11.582815",
     "geom:latitude":11.443284,
     "geom:longitude":-84.709024,
@@ -119,12 +119,13 @@
         "hasc:id":"NI.SJ.SM",
         "qs_pg:id":260433
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NI",
     "wof:created":1459010218,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f817e029900fb89c987368fad01ba040",
+    "wof:geomhash":"dc94c21e7c03d1b64d34f68147596ba1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421205287,
-    "wof:lastmodified":1627522477,
+    "wof:lastmodified":1695886101,
     "wof:name":"San Miguelito",
     "wof:parent_id":85675465,
     "wof:placetype":"county",

--- a/data/856/325/99/85632599.geojson
+++ b/data/856/325/99/85632599.geojson
@@ -1131,6 +1131,7 @@
         "hasc:id":"NI",
         "icao:code":"YN",
         "ioc:id":"NCA",
+        "iso:code":"NI",
         "itu:id":"NCG",
         "loc:id":"n80009698",
         "m49:code":"558",
@@ -1145,6 +1146,7 @@
         "wk:page":"Nicaragua",
         "wmo:id":"NK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:country_alpha3":"NIC",
     "wof:geom_alt":[
@@ -1166,7 +1168,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639560,
+    "wof:lastmodified":1695881218,
     "wof:name":"Nicaragua",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/754/61/85675461.geojson
+++ b/data/856/754/61/85675461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.182113,
-    "geom:area_square_m":2207519083.061435,
+    "geom:area_square_m":2207518320.806355,
     "geom:bbox":"-86.171405,11.047692,-85.175616,11.695326",
     "geom:latitude":11.389029,
     "geom:longitude":-85.803554,
@@ -272,17 +272,19 @@
         "gn:id":3617051,
         "gp:id":2346431,
         "hasc:id":"NI.RI",
+        "iso:code":"NI-RI",
         "iso:id":"NI-RI",
         "qs_pg:id":890094,
         "unlc:id":"NI-RI",
         "wd:id":"Q728127",
         "wk:page":"Rivas Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"90e667eb2c6fd51c6f75aa0b9ba7f839",
+    "wof:geomhash":"5dcb382fe1d4c8ac36809ff125d55fe9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -297,7 +299,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848454,
+    "wof:lastmodified":1695884954,
     "wof:name":"Rivas",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/65/85675465.geojson
+++ b/data/856/754/65/85675465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.631673,
-    "geom:area_square_m":7660535266.238631,
+    "geom:area_square_m":7660534131.030437,
     "geom:bbox":"-85.178506,10.711032,-83.664415,11.88244",
     "geom:latitude":11.252162,
     "geom:longitude":-84.481487,
@@ -324,17 +324,19 @@
         "gn:id":3617056,
         "gp:id":2346430,
         "hasc:id":"NI.SJ",
+        "iso:code":"NI-SJ",
         "iso:id":"NI-SJ",
         "qs_pg:id":890092,
         "unlc:id":"NI-SJ",
         "wd:id":"Q728155",
         "wk:page":"R\u00edo San Juan Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"892c564ba615bcc9fbb0499f79bb9f7f",
+    "wof:geomhash":"8efca5b88e1aa158772a8d49d6f0dcab",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848455,
+    "wof:lastmodified":1695884374,
     "wof:name":"Rio San Juan",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/67/85675467.geojson
+++ b/data/856/754/67/85675467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.239938,
-    "geom:area_square_m":27052301004.243019,
+    "geom:area_square_m":27052301664.889347,
     "geom:bbox":"-85.210747,10.946124,-83.488206,13.290139",
     "geom:latitude":12.376276,
     "geom:longitude":-84.250165,
@@ -149,15 +149,17 @@
         "gn:id":3830308,
         "gp:id":20069832,
         "hasc:id":"NI.AS",
+        "iso:code":"NI-AS",
         "iso:id":"NI-AS",
         "qs_pg:id":236283,
         "unlc:id":"NI-AS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"72151e54f7cab7e2600c7898c3296a28",
+    "wof:geomhash":"d37a4f8fcab70e5242b06d0b8d2083b8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -172,7 +174,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1627522476,
+    "wof:lastmodified":1695884755,
     "wof:name":"Atl\u00e1ntico Sur",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/71/85675471.geojson
+++ b/data/856/754/71/85675471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094813,
-    "geom:area_square_m":1147845464.917986,
+    "geom:area_square_m":1147845446.014254,
     "geom:bbox":"-86.452684,11.514449,-86.077575,11.954602",
     "geom:latitude":11.742716,
     "geom:longitude":-86.249757,
@@ -308,17 +308,19 @@
         "gn:id":3620481,
         "gp:id":2346418,
         "hasc:id":"NI.CA",
+        "iso:code":"NI-CA",
         "iso:id":"NI-CA",
         "qs_pg:id":1222702,
         "unlc:id":"NI-CA",
         "wd:id":"Q461133",
         "wk:page":"Carazo Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89631869d2e8b43e81b32d5f51824805",
+    "wof:geomhash":"597494ebe1e549e5c8603855fd2ac2b8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848456,
+    "wof:lastmodified":1695884955,
     "wof:name":"Carazo",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/77/85675477.geojson
+++ b/data/856/754/77/85675477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088285,
-    "geom:area_square_m":1068290361.237606,
+    "geom:area_square_m":1068289947.802186,
     "geom:bbox":"-86.129896,11.601649,-85.785191,12.213491",
     "geom:latitude":11.876977,
     "geom:longitude":-85.966247,
@@ -278,17 +278,19 @@
         "gn:id":3619135,
         "gp:id":2346422,
         "hasc:id":"NI.GR",
+        "iso:code":"NI-GR",
         "iso:id":"NI-GR",
         "qs_pg:id":318538,
         "unlc:id":"NI-GR",
         "wd:id":"Q258405",
         "wk:page":"Granada Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5ab3157adc5771e26996ffdd2ef97660",
+    "wof:geomhash":"a0eb48104c2708eca4d9be8c6d291f56",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848456,
+    "wof:lastmodified":1695884955,
     "wof:name":"Granada",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/81/85675481.geojson
+++ b/data/856/754/81/85675481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.796488,
-    "geom:area_square_m":9566322181.295382,
+    "geom:area_square_m":9566321855.212715,
     "geom:bbox":"-86.257929,12.995168,-84.83258,14.579734",
     "geom:latitude":13.74973,
     "geom:longitude":-85.51425,
@@ -308,17 +308,19 @@
         "gn:id":3618928,
         "gp:id":2346423,
         "hasc:id":"NI.JI",
+        "iso:code":"NI-JI",
         "iso:id":"NI-JI",
         "qs_pg:id":219581,
         "unlc:id":"NI-JI",
         "wd:id":"Q728120",
         "wk:page":"Jinotega Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f408485876258e06c9a03962d6d0b63a",
+    "wof:geomhash":"5589521530ecde40fcd399429ce33896",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848455,
+    "wof:lastmodified":1695884954,
     "wof:name":"Jinotega",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/85/85675485.geojson
+++ b/data/856/754/85/85675485.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.656353,
-    "geom:area_square_m":31872879222.991863,
+    "geom:area_square_m":31872879214.740654,
     "geom:bbox":"-85.513192,13.018142,-83.183673,15.034255",
     "geom:latitude":13.975958,
     "geom:longitude":-84.248564,
@@ -150,15 +150,17 @@
         "gn:id":3830307,
         "gp:id":20069833,
         "hasc:id":"NI.AN",
+        "iso:code":"NI-AN",
         "iso:id":"NI-AN",
         "qs_pg:id":236284,
         "unlc:id":"NI-AN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cd35c654fc58c4045af994c2929174f8",
+    "wof:geomhash":"875fc9f6fcf17cae1e1f11c30eb92566",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -173,7 +175,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1627522476,
+    "wof:lastmodified":1695884755,
     "wof:name":"Atl\u00e1ntico Norte",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/89/85675489.geojson
+++ b/data/856/754/89/85675489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.425093,
-    "geom:area_square_m":5130030012.404552,
+    "geom:area_square_m":5130030732.948115,
     "geom:bbox":"-87.110886,11.98377,-86.275836,13.127306",
     "geom:latitude":12.584109,
     "geom:longitude":-86.63744,
@@ -282,17 +282,19 @@
         "gn:id":3618029,
         "gp:id":2346424,
         "hasc:id":"NI.LE",
+        "iso:code":"NI-LE",
         "iso:id":"NI-LE",
         "qs_pg:id":318539,
         "unlc:id":"NI-LE",
         "wd:id":"Q586818",
         "wk:page":"Le\u00f3n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"11db8fa22624c9c2784e8ade6274bc91",
+    "wof:geomhash":"72e27b5228b7cac211c873423eaa0d41",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848455,
+    "wof:lastmodified":1695884374,
     "wof:name":"Le\u00f3n",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/95/85675495.geojson
+++ b/data/856/754/95/85675495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.289683,
-    "geom:area_square_m":3501022513.563382,
+    "geom:area_square_m":3501022756.119752,
     "geom:bbox":"-86.673614,11.715189,-85.804186,12.641778",
     "geom:latitude":12.203479,
     "geom:longitude":-86.268401,
@@ -317,17 +317,19 @@
         "gn:id":3617762,
         "gp:id":2346426,
         "hasc:id":"NI.MN",
+        "iso:code":"NI-MN",
         "iso:id":"NI-MN",
         "qs_pg:id":318540,
         "unlc:id":"NI-MN",
         "wd:id":"Q260009",
         "wk:page":"Managua Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"74dfc7f1c4a580e2c25f37f805ec3f99",
+    "wof:geomhash":"1e15b9fe46615ec9232ab9b386a22ee3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -342,7 +344,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848455,
+    "wof:lastmodified":1695884954,
     "wof:name":"Managua",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/754/99/85675499.geojson
+++ b/data/856/754/99/85675499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051241,
-    "geom:area_square_m":619748890.51517,
+    "geom:area_square_m":619748177.72454,
     "geom:bbox":"-86.297616,11.834025,-85.961348,12.151979",
     "geom:latitude":12.005286,
     "geom:longitude":-86.102905,
@@ -308,17 +308,19 @@
         "gn:id":3617722,
         "gp:id":2346427,
         "hasc:id":"NI.MS",
+        "iso:code":"NI-MS",
         "iso:id":"NI-MS",
         "qs_pg:id":1046996,
         "unlc:id":"NI-MS",
         "wd:id":"Q570358",
         "wk:page":"Masaya Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76d8f047cd5f81768278abc0ac4ed2fd",
+    "wof:geomhash":"7ac2b9100b63056e37f0f9312c8028e7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848456,
+    "wof:lastmodified":1695884954,
     "wof:name":"Masaya",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/03/85675503.geojson
+++ b/data/856/755/03/85675503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.386878,
-    "geom:area_square_m":4664163285.452307,
+    "geom:area_square_m":4664162251.351213,
     "geom:bbox":"-87.685091,12.397112,-86.661735,13.300735",
     "geom:latitude":12.841015,
     "geom:longitude":-87.088135,
@@ -314,17 +314,19 @@
         "gn:id":3620380,
         "gp:id":2346419,
         "hasc:id":"NI.CI",
+        "iso:code":"NI-CI",
         "iso:id":"NI-CI",
         "qs_pg:id":1222703,
         "unlc:id":"NI-CI",
         "wd:id":"Q644024",
         "wk:page":"Chinandega Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a90734f88c636c57c1d75dc7fe996e9d",
+    "wof:geomhash":"41316770c4eca793062b2b814b085747",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848452,
+    "wof:lastmodified":1695884954,
     "wof:name":"Chinandega",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/05/85675505.geojson
+++ b/data/856/755/05/85675505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189573,
-    "geom:area_square_m":2282430210.80646,
+    "geom:area_square_m":2282430479.75934,
     "geom:bbox":"-86.750041,12.850431,-86.096843,13.432635",
     "geom:latitude":13.171995,
     "geom:longitude":-86.394647,
@@ -315,17 +315,19 @@
         "gn:id":3619193,
         "gp:id":2346421,
         "hasc:id":"NI.ES",
+        "iso:code":"NI-ES",
         "iso:id":"NI-ES",
         "qs_pg:id":1222704,
         "unlc:id":"NI-ES",
         "wd:id":"Q728015",
         "wk:page":"Estel\u00ed Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"213f71569b03634d67827e8e824d07a6",
+    "wof:geomhash":"486682465fba7825b0581f0ddb756581",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -340,7 +342,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848453,
+    "wof:lastmodified":1695884374,
     "wof:name":"Estel\u00ed",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/11/85675511.geojson
+++ b/data/856/755/11/85675511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142707,
-    "geom:area_square_m":1715965877.509024,
+    "geom:area_square_m":1715965453.296707,
     "geom:bbox":"-86.770881,13.186588,-86.069743,13.664493",
     "geom:latitude":13.48237,
     "geom:longitude":-86.470825,
@@ -307,17 +307,19 @@
         "gn:id":3617796,
         "gp:id":2346425,
         "hasc:id":"NI.MD",
+        "iso:code":"NI-MD",
         "iso:id":"NI-MD",
         "qs_pg:id":1252196,
         "unlc:id":"NI-MD",
         "wd:id":"Q728056",
         "wk:page":"Madriz Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09b8f304585fde1664f9ce51160efaad",
+    "wof:geomhash":"d91d07878dc065c56b25f69f2924af34",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848453,
+    "wof:lastmodified":1695884954,
     "wof:name":"Madriz",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/13/85675513.geojson
+++ b/data/856/755/13/85675513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.572862,
-    "geom:area_square_m":6904520403.119654,
+    "geom:area_square_m":6904520119.481265,
     "geom:bbox":"-86.293759,12.53623,-85.07269,13.34859",
     "geom:latitude":12.907945,
     "geom:longitude":-85.676542,
@@ -302,17 +302,19 @@
         "gn:id":3617707,
         "gp:id":2346428,
         "hasc:id":"NI.MT",
+        "iso:code":"NI-MT",
         "iso:id":"NI-MT",
         "qs_pg:id":890091,
         "unlc:id":"NI-MT",
         "wd:id":"Q728099",
         "wk:page":"Matagalpa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e060177d29f850cb8a4671b83e2fc26a",
+    "wof:geomhash":"1141c0502915c7c51f950ef4de55c896",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848454,
+    "wof:lastmodified":1695884954,
     "wof:name":"Matagalpa",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/17/85675517.geojson
+++ b/data/856/755/17/85675517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.24404,
-    "geom:area_square_m":2931236577.281032,
+    "geom:area_square_m":2931236469.039461,
     "geom:bbox":"-86.766783,13.466095,-85.824854,14.06954",
     "geom:latitude":13.740871,
     "geom:longitude":-86.211333,
@@ -305,17 +305,19 @@
         "gn:id":3617458,
         "gp:id":2346429,
         "hasc:id":"NI.NS",
+        "iso:code":"NI-NS",
         "iso:id":"NI-NS",
         "qs_pg:id":1097046,
         "unlc:id":"NI-NS",
         "wd:id":"Q728022",
         "wk:page":"Nueva Segovia Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b416eec2401603437279d13848704752",
+    "wof:geomhash":"9244eaee283249f0246a3496f275e862",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848453,
+    "wof:lastmodified":1695884954,
     "wof:name":"Nueva Segovia",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/21/85675521.geojson
+++ b/data/856/755/21/85675521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.344995,
-    "geom:area_square_m":4165023809.572712,
+    "geom:area_square_m":4165024412.090761,
     "geom:bbox":"-85.982277,12.058253,-84.957312,12.802382",
     "geom:latitude":12.485699,
     "geom:longitude":-85.50821,
@@ -305,17 +305,19 @@
         "gn:id":3620673,
         "gp:id":2346417,
         "hasc:id":"NI.BO",
+        "iso:code":"NI-BO",
         "iso:id":"NI-BO",
         "qs_pg:id":890090,
         "unlc:id":"NI-BO",
         "wd:id":"Q280973",
         "wk:page":"Boaco Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"08a2f3ce98ce2df658dfd51a2bcc2f05",
+    "wof:geomhash":"06c08b806f8d6fe1fd85ef3583679511",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848453,
+    "wof:lastmodified":1695884954,
     "wof:name":"Boaco",
     "wof:parent_id":85632599,
     "wof:placetype":"region",

--- a/data/856/755/25/85675525.geojson
+++ b/data/856/755/25/85675525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.533715,
-    "geom:area_square_m":6452693225.46139,
+    "geom:area_square_m":6452692980.468601,
     "geom:bbox":"-85.681631,11.637121,-84.523992,12.632064",
     "geom:latitude":12.105551,
     "geom:longitude":-85.132371,
@@ -305,17 +305,19 @@
         "gn:id":3620368,
         "gp:id":2346420,
         "hasc:id":"NI.CO",
+        "iso:code":"NI-CO",
         "iso:id":"NI-CO",
         "qs_pg:id":1175856,
         "unlc:id":"NI-CO",
         "wd:id":"Q498443",
         "wk:page":"Chontales Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f988875babbc0cad04cdf672a26803bd",
+    "wof:geomhash":"9566ce6385c1b7caab3c1fdb9c7b1282",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690848454,
+    "wof:lastmodified":1695884954,
     "wof:name":"Chontales",
     "wof:parent_id":85632599,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.